### PR TITLE
Fix conn build warning in page controller tests

### DIFF
--- a/test/controllers/page_controller_test.exs
+++ b/test/controllers/page_controller_test.exs
@@ -6,13 +6,13 @@ defmodule Pairmotron.PageControllerTest do
     assert html_response(conn, 200) =~ "Pairs for"
   end
 
-  test "lists one active user" do
+  test "lists one active user", %{conn: conn} do
     {:ok, user} = Pairmotron.Repo.insert(%Pairmotron.User{name: "junk_name", email: "a", active: true})
     conn = get conn, "/"
     assert html_response(conn, 200) =~ user.name
   end
 
-  test "does not list an inactive user" do
+  test "does not list an inactive user", %{conn: conn} do
     {:ok, user} = Pairmotron.Repo.insert(%Pairmotron.User{name: "junk_name", email: "a", active: false})
     conn = get conn, "/"
     refute html_response(conn, 200) =~ user.name


### PR DESCRIPTION
@mbramson The tests were warning about using build_conn instead of conn. This removes that warning.