### PR TITLE
Create Pair model and add feature to repairify

### DIFF
--- a/priv/repo/migrations/20161111182817_create_pair.exs
+++ b/priv/repo/migrations/20161111182817_create_pair.exs
@@ -6,11 +6,10 @@ defmodule Pairmotron.Repo.Migrations.CreatePair do
       add :year, :integer, primary_key: true
       add :week, :integer, primary_key: true
       add :pair_group, :integer
-      add :user_id, references(:users, on_delete: :nothing), primary_key: true
 
       timestamps()
     end
-    create index(:pairs, [:user_id, :year, :week])
+    create index(:pairs, [:year, :week])
 
   end
 end

--- a/priv/repo/migrations/20161111182817_create_pair.exs
+++ b/priv/repo/migrations/20161111182817_create_pair.exs
@@ -5,7 +5,6 @@ defmodule Pairmotron.Repo.Migrations.CreatePair do
     create table(:pairs) do
       add :year, :integer, primary_key: true
       add :week, :integer, primary_key: true
-      add :pair_group, :integer
 
       timestamps()
     end

--- a/priv/repo/migrations/20161111182817_create_pair.exs
+++ b/priv/repo/migrations/20161111182817_create_pair.exs
@@ -1,0 +1,16 @@
+defmodule Pairmotron.Repo.Migrations.CreatePair do
+  use Ecto.Migration
+
+  def change do
+    create table(:pairs) do
+      add :year, :integer, primary_key: true
+      add :week, :integer, primary_key: true
+      add :pair_group, :integer
+      add :user_id, references(:users, on_delete: :nothing), primary_key: true
+
+      timestamps()
+    end
+    create index(:pairs, [:user_id, :year, :week])
+
+  end
+end

--- a/priv/repo/migrations/20161114171500_create_userpair.exs
+++ b/priv/repo/migrations/20161114171500_create_userpair.exs
@@ -1,0 +1,17 @@
+defmodule Pairmotron.Repo.Migrations.CreateUserPair do
+  use Ecto.Migration
+
+  def change do
+    create unique_index(:pairs, [:id])
+
+    create table(:users_pairs) do
+      add :user_id, references(:users, on_delete: :delete_all)
+      add :pair_id, references(:pairs, on_delete: :delete_all)
+
+      timestamps()
+    end
+    create index(:users_pairs, [:user_id])
+    create index(:users_pairs, [:pair_id])
+
+  end
+end

--- a/test/controllers/page_controller_test.exs
+++ b/test/controllers/page_controller_test.exs
@@ -17,4 +17,28 @@ defmodule Pairmotron.PageControllerTest do
     conn = get conn, "/"
     refute html_response(conn, 200) =~ user.name
   end
+
+  describe "pairifying" do
+    setup do
+      {:ok, usera} = Pairmotron.Repo.insert(%Pairmotron.User{name: "usera", email: "a", active: true})
+      {:ok, userb} = Pairmotron.Repo.insert(%Pairmotron.User{name: "userb", email: "b", active: true})
+      conn = get build_conn, page_path(build_conn, :show, 2016, 40)
+      {:ok, [conn: conn, usera: usera, userb: userb]}
+    end
+
+    test "saves and stores the pairs", %{conn: conn, usera: usera, userb: userb} do
+      assert html_response(conn, 200) =~ usera.name
+      assert html_response(conn, 200) =~ userb.name
+      {:ok, userc} = Pairmotron.Repo.insert(%Pairmotron.User{name: "userc", email: "c", active: true})
+      conn = get conn, page_path(conn, :show, 2016, 40)
+      refute html_response(conn, 200) =~ userc.name
+    end
+
+    test "repairifies", %{conn: conn} do
+      {:ok, userc} = Pairmotron.Repo.insert(%Pairmotron.User{name: "userc", email: "c", active: true})
+      conn = delete conn, page_path(conn, :delete, 2016, 40)
+      conn = get conn, page_path(conn, :show, 2016, 40)
+      assert html_response(conn, 200) =~ userc.name
+    end
+  end
 end

--- a/test/models/pair_test.exs
+++ b/test/models/pair_test.exs
@@ -3,7 +3,7 @@ defmodule Pairmotron.PairTest do
 
   alias Pairmotron.Pair
 
-  @valid_attrs %{pair_group: 42, week: 42, year: 42, user_id: 42}
+  @valid_attrs %{pair_group: 42, week: 42, year: 42}
   @invalid_attrs %{}
 
   test "changeset with valid attributes" do

--- a/test/models/pair_test.exs
+++ b/test/models/pair_test.exs
@@ -1,0 +1,18 @@
+defmodule Pairmotron.PairTest do
+  use Pairmotron.ModelCase
+
+  alias Pairmotron.Pair
+
+  @valid_attrs %{pair_group: 42, week: 42, year: 42, user_id: 42}
+  @invalid_attrs %{}
+
+  test "changeset with valid attributes" do
+    changeset = Pair.changeset(%Pair{}, @valid_attrs)
+    assert changeset.valid?
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = Pair.changeset(%Pair{}, @invalid_attrs)
+    refute changeset.valid?
+  end
+end

--- a/test/models/user_pair_test.exs
+++ b/test/models/user_pair_test.exs
@@ -1,0 +1,18 @@
+defmodule Pairmotron.UserPairTest do
+  use Pairmotron.ModelCase
+
+  alias Pairmotron.UserPair
+
+  @valid_attrs %{pair_id: 42, user_id: 42}
+  @invalid_attrs %{}
+
+  test "changeset with valid attributes" do
+    changeset = UserPair.changeset(%UserPair{}, @valid_attrs)
+    assert changeset.valid?
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = UserPair.changeset(%UserPair{}, @invalid_attrs)
+    refute changeset.valid?
+  end
+end

--- a/web/controllers/page_controller.ex
+++ b/web/controllers/page_controller.ex
@@ -1,8 +1,9 @@
 defmodule Pairmotron.PageController do
   use Pairmotron.Web, :controller
 
-  alias Pairmotron.User
   alias Pairmotron.Pair
+  alias Pairmotron.User
+  alias Pairmotron.UserPair
   alias Pairmotron.Mixer
   alias Pairmotron.Pairer
 
@@ -48,9 +49,7 @@ defmodule Pairmotron.PageController do
 
   defp fetch_users_from_pairs(pairs) do
     pairs
-      |> Repo.preload([:user])
-      |> Enum.map(fn(p) -> p.user end)
-      |> Pairer.generate_pairs
+      |> Repo.preload([:users])
   end
 
   defp generate_pairs(year, week) do
@@ -66,7 +65,8 @@ defmodule Pairmotron.PageController do
   end
 
   defp make_pair(users, index, year, week) do
+    pair = Repo.insert! %Pair{year: year, week: week, pair_group: index}
     users
-      |> Enum.map(fn(user) -> %Pair{year: year, week: week, user_id: user.id, pair_group: index} end)
+      |> Enum.map(fn(user) -> %UserPair{pair_id: pair.id, user_id: user.id} end)
   end
 end

--- a/web/controllers/page_controller.ex
+++ b/web/controllers/page_controller.ex
@@ -30,12 +30,13 @@ defmodule Pairmotron.PageController do
   end
 
   defp fetch_or_gen(year, week) do
-    case fetch_pairs(year, week) |> fetch_user_pairs do
+    case fetch_pairs(year, week) do
       [] ->
         generate_pairs(year, week)
-        fetch_pairs(year, week) |> fetch_user_pairs
+        fetch_pairs(year, week)
       pairs -> pairs
     end
+      |> fetch_users_from_pairs
   end
 
   defp fetch_pairs(year, week) do
@@ -45,7 +46,7 @@ defmodule Pairmotron.PageController do
       |> Repo.all
   end
 
-  defp fetch_user_pairs(pairs) do
+  defp fetch_users_from_pairs(pairs) do
     pairs
       |> Repo.preload([:user])
       |> Enum.map(fn(p) -> p.user end)

--- a/web/controllers/page_controller.ex
+++ b/web/controllers/page_controller.ex
@@ -43,7 +43,7 @@ defmodule Pairmotron.PageController do
   defp fetch_pairs(year, week) do
     Pair
       |> where(year: ^year, week: ^week)
-      |> order_by(:pair_group)
+      |> order_by(:id)
       |> Repo.all
   end
 
@@ -58,15 +58,14 @@ defmodule Pairmotron.PageController do
       |> Repo.all
       |> Mixer.mixify(week)
       |> Pairer.generate_pairs
-      |> Enum.with_index
-      |> Enum.map(fn({users, pair_index}) -> make_pair(users, pair_index, year, week) end)
+      |> Enum.map(fn(users) -> make_pairs(users, year, week) end)
       |> List.flatten
       |> Enum.map(fn(p) -> Repo.insert! p end)
   end
 
-  defp make_pair(users, index, year, week) do
-    pair = Repo.insert! %Pair{year: year, week: week, pair_group: index}
+  defp make_pairs(users, year, week) do
+    pair = Repo.insert! Pair.changeset(%Pair{}, %{year: year, week: week})
     users
-      |> Enum.map(fn(user) -> %UserPair{pair_id: pair.id, user_id: user.id} end)
+      |> Enum.map(fn(user) -> UserPair.changeset(%UserPair{}, %{pair_id: pair.id, user_id: user.id}) end)
   end
 end

--- a/web/controllers/page_controller.ex
+++ b/web/controllers/page_controller.ex
@@ -2,14 +2,70 @@ defmodule Pairmotron.PageController do
   use Pairmotron.Web, :controller
 
   alias Pairmotron.User
+  alias Pairmotron.Pair
   alias Pairmotron.Mixer
   alias Pairmotron.Pairer
 
   def index(conn, _params) do
-    {_year, week} = Timex.iso_week(Timex.today)
-    pairs = Repo.all(User.active_users)
+    {year, week} = Timex.iso_week(Timex.today)
+    pairs = fetch_or_gen(year, week)
+    render conn, "index.html", pairs: pairs, year: year, week: week
+  end
+
+  def show(conn, %{"year" => y, "week" => w}) do
+    {year, _} = y |> Integer.parse
+    {week, _} = w |> Integer.parse
+    pairs = fetch_or_gen(year, week)
+    render conn, "index.html", pairs: pairs, year: year, week: week
+  end
+
+  def delete(conn, %{"year" => y, "week" => w}) do
+    {year, _} = y |> Integer.parse
+    {week, _} = w |> Integer.parse
+    fetch_pairs(year, week)
+      |> Enum.map(fn(p) -> Repo.delete! p end)
+    conn
+      |> put_flash(:info, "Repairified")
+      |> redirect(to: page_path(conn, :show, year, week))
+  end
+
+  defp fetch_or_gen(year, week) do
+    case fetch_pairs(year, week) |> fetch_user_pairs do
+      [] ->
+        generate_pairs(year, week)
+        fetch_pairs(year, week) |> fetch_user_pairs
+      pairs -> pairs
+    end
+  end
+
+  defp fetch_pairs(year, week) do
+    Pair
+      |> where(year: ^year, week: ^week)
+      |> order_by(:pair_group)
+      |> Repo.all
+  end
+
+  defp fetch_user_pairs(pairs) do
+    pairs
+      |> Repo.preload([:user])
+      |> Enum.map(fn(p) -> p.user end)
+      |> Pairer.generate_pairs
+  end
+
+  defp generate_pairs(year, week) do
+    User.active_users
+      |> order_by(:id)
+      |> Repo.all
       |> Mixer.mixify(week)
       |> Pairer.generate_pairs
-    render conn, "index.html", pairs: pairs
+      |> Enum.with_index
+      |> Enum.map(fn({users, pair_index}) -> make_pair(users, pair_index, year, week) end)
+      |> List.flatten
+      |> Enum.map(fn(p) -> Repo.insert! p end)
+  end
+
+  defp make_pair(users, index, year, week) do
+    users
+      |> Enum.map(fn(user) -> %Pair{year: year, week: week, user_id: user.id, pair_group: index} end)
   end
 end

--- a/web/models/pair.ex
+++ b/web/models/pair.ex
@@ -7,6 +7,9 @@ defmodule Pairmotron.Pair do
     field :pair_group, :integer
     belongs_to :user, Pairmotron.User
 
+    @required_fields ~w(year week pair_group user_id)
+    @optional_fields ~w()
+
     timestamps()
   end
 
@@ -15,7 +18,6 @@ defmodule Pairmotron.Pair do
   """
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:year, :week, :pair_group, :user_id])
-    |> validate_required([:year, :week, :pair_group, :user_id])
+    |> cast(params, @required_fields, @optional_fields)
   end
 end

--- a/web/models/pair.ex
+++ b/web/models/pair.ex
@@ -4,10 +4,9 @@ defmodule Pairmotron.Pair do
   schema "pairs" do
     field :year, :integer
     field :week, :integer
-    field :pair_group, :integer
     many_to_many :users, Pairmotron.User, join_through: "users_pairs"
 
-    @required_fields ~w(year week pair_group)
+    @required_fields ~w(year week)
     @optional_fields ~w()
 
     timestamps()

--- a/web/models/pair.ex
+++ b/web/models/pair.ex
@@ -1,0 +1,21 @@
+defmodule Pairmotron.Pair do
+  use Pairmotron.Web, :model
+
+  schema "pairs" do
+    field :year, :integer
+    field :week, :integer
+    field :pair_group, :integer
+    belongs_to :user, Pairmotron.User
+
+    timestamps()
+  end
+
+  @doc """
+  Builds a changeset based on the `struct` and `params`.
+  """
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:year, :week, :pair_group, :user_id])
+    |> validate_required([:year, :week, :pair_group, :user_id])
+  end
+end

--- a/web/models/user_pair.ex
+++ b/web/models/user_pair.ex
@@ -1,13 +1,11 @@
-defmodule Pairmotron.Pair do
+defmodule Pairmotron.UserPair do
   use Pairmotron.Web, :model
 
-  schema "pairs" do
-    field :year, :integer
-    field :week, :integer
-    field :pair_group, :integer
-    many_to_many :users, Pairmotron.User, join_through: "users_pairs"
+  schema "users_pairs" do
+    belongs_to :user, Pairmotron.User
+    belongs_to :pair, Pairmotron.Pair
 
-    @required_fields ~w(year week pair_group)
+    @required_fields ~w(pair_id user_id)
     @optional_fields ~w()
 
     timestamps()

--- a/web/router.ex
+++ b/web/router.ex
@@ -19,6 +19,8 @@ defmodule Pairmotron.Router do
     get "/", PageController, :index
     resources "/users", UserController
     resources "/projects", ProjectController
+    get "/:year/:week", PageController, :show
+    delete "/:year/:week", PageController, :delete
   end
 
   # Other scopes may use custom stacks.

--- a/web/templates/page/index.html.eex
+++ b/web/templates/page/index.html.eex
@@ -3,7 +3,7 @@
   <%= for pair <- @pairs do %>
     <li class="list-group-item">
       <div class="row">
-        <%= for user <- pair do %>
+        <%= for user <- pair.users do %>
           <div class="col-sm-4">
             <p><%= user.name %></p>
           </div>

--- a/web/templates/page/index.html.eex
+++ b/web/templates/page/index.html.eex
@@ -1,4 +1,4 @@
-<h2>Pairs for <%= @year %> week <%= @week %></h2>
+<h2>Pairs for week <%= @week %> of <%= @year %></h2>
 <ul class="list-group">
   <%= for pair <- @pairs do %>
     <li class="list-group-item">

--- a/web/templates/page/index.html.eex
+++ b/web/templates/page/index.html.eex
@@ -1,4 +1,4 @@
-<h2>Pairs for <%= Timex.today %></h2>
+<h2>Pairs for <%= @year %> week <%= @week %></h2>
 <ul class="list-group">
   <%= for pair <- @pairs do %>
     <li class="list-group-item">
@@ -12,3 +12,9 @@
     </li>
   <% end %>
 </ul>
+<%= form_for @conn, page_path(@conn, :delete, @year, @week), [as: :repairify, method: "delete"], fn _ -> %>
+  <div class="form-group">
+    <%= submit "Repairify", class: "btn btn-danger" %>
+  </div>
+<% end %>
+


### PR DESCRIPTION
@mbramson Creates a pair model with a 3-part composite key. The front page now stores and retrieves these pairs instead of recalculating the pairs.  Added a button to repairify active users. Added routes to show the pairs of a specific year and week (and to repairify, probably want to change that in the future). Made the pairification consistent with a better query to fetch users.

There's some refactoring we can do once we want to add projects to the pairs. We might want to move the indexing to Pairer, refactor the template, move the Pair query to the model, etc. Open to suggestions or further issues.

Closes #3 