### PR TITLE
39: Add guardian token to authentication

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -22,6 +22,21 @@ config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   metadata: [:request_id]
 
+config :guardian, Guardian,
+  allowed_algos: ["ES512"],
+  verify_module: Guardian.JWT,
+  issuer: "Pairmotron",
+  ttl: { 30, :days },
+  verify_issuer: true, # optional
+  secret_key: %{
+    "crv" => "P-521",
+    "d" => "axDuTtGavPjnhlfnYAwkHa4qyfz2fdseppXEzmKpQyY0xd3bGpYLEF4ognDpRJm5IRaM31Id2NfEtDFw4iTbDSE",
+    "kty" => "EC",
+    "x" => "AL0H8OvP5NuboUoj8Pb3zpBcDyEJN907wMxrCy7H2062i3IRPF5NQ546jIJU3uQX5KN2QB_Cq6R_SUqyVZSNpIfC",
+    "y" => "ALdxLuo6oKLoQ-xLSkShv_TA0di97I9V92sg1MKFava5hKGST1EKiVQnZMrN3HO8LtLT78SNTgwJSQHAXIUaA-lV"
+  },
+  serializer: Pairmotron.GuardianSerializer
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env}.exs"

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -27,3 +27,5 @@ config :pairmotron, Pairmotron.Repo,
   pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
   ssl: true
 
+config :guardian, Guardian,
+  secret_key: System.get_env("GUARDIAN_JWK_KEY")

--- a/lib/guardian_serializer.ex
+++ b/lib/guardian_serializer.ex
@@ -1,0 +1,11 @@
+defmodule Pairmotron.GuardianSerializer do
+  @behaviour Guardian.Serializer
+
+  alias Pairmotron.{Repo, User}
+
+  def for_token(user = %User{}), do: { :ok, "User:#{user.id}" }
+  def for_token(_), do: { :error, "Unknown resource type" }
+
+  def from_token("User:" <> id), do: { :ok, Repo.get(User, id) }
+  def from_token(_), do: { :error, "Unknown resource type" }
+end

--- a/mix.exs
+++ b/mix.exs
@@ -41,7 +41,8 @@ defmodule Pairmotron.Mixfile do
      {:timex, "~> 3.0"},
      {:mix_test_watch, "~> 0.2", only: :dev},
      {:comeonin, "~> 2.6"},
-     {:ex_machina, "~> 1.0"}]
+     {:ex_machina, "~> 1.0"},
+     {:guardian, "~> 0.13.0"}]
   end
 
   # Aliases are shortcuts or tasks specific to the current project.

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
-%{"certifi": {:hex, :certifi, "0.7.0", "861a57f3808f7eb0c2d1802afeaae0fa5de813b0df0979153cbafcd853ababaf", [:rebar3], []},
+%{"base64url": {:hex, :base64url, "0.0.1", "36a90125f5948e3afd7be97662a1504b934dd5dac78451ca6e9abf85a10286be", [:rebar], []},
+  "certifi": {:hex, :certifi, "0.7.0", "861a57f3808f7eb0c2d1802afeaae0fa5de813b0df0979153cbafcd853ababaf", [:rebar3], []},
   "combine": {:hex, :combine, "0.9.2", "cd3c8721f378ebe032487d8a4fa2ced3181a456a3c21b16464da8c46904bb552", [:mix], []},
   "comeonin": {:hex, :comeonin, "2.6.0", "74c288338b33205f9ce97e2117bb9a2aaab103a1811d243443d76fdb62f904ac", [:mix, :make, :make], []},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
@@ -10,10 +11,12 @@
   "ex_machina": {:hex, :ex_machina, "1.0.2", "1cc49e1a09e3f7ab2ecb630c17f14c2872dc4ec145d6d05a9c3621936a63e34f", [:mix], [{:ecto, "~> 2.0", [hex: :ecto, optional: true]}]},
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},
   "gettext": {:hex, :gettext, "0.12.1", "c0624f52763469ef7a3674919ae28b8286d88195b90fa1516180f31bbbd26d14", [:mix], []},
+  "guardian": {:hex, :guardian, "0.13.0", "37c5b5302617276093570ee938baca146f53e1d5de1f5c2b8effb1d2fea596d2", [:mix], [{:jose, "~> 1.8", [hex: :jose, optional: false]}, {:phoenix, "~> 1.2.0", [hex: :phoenix, optional: true]}, {:plug, "~> 1.0", [hex: :plug, optional: false]}, {:poison, ">= 1.3.0", [hex: :poison, optional: false]}, {:uuid, ">=1.1.1", [hex: :uuid, optional: false]}]},
   "hackney": {:hex, :hackney, "1.6.3", "d489d7ca2d4323e307bedc4bfe684323a7bf773ecfd77938f3ee8074e488e140", [:rebar3, :mix], [{:certifi, "0.7.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, optional: false]}]},
   "hound": {:hex, :hound, "1.0.2", "b6dd20142d00c28009fad503a23fa4a76bc11899e0d198f36a9c1448427788b2", [:mix], [{:httpoison, "~> 0.8", [hex: :httpoison, optional: false]}, {:poison, ">= 1.4.0", [hex: :poison, optional: false]}]},
   "httpoison": {:hex, :httpoison, "0.10.0", "4727b3a5e57e9a4ff168a3c2883e20f1208103a41bccc4754f15a9366f49b676", [:mix], [{:hackney, "~> 1.6.3", [hex: :hackney, optional: false]}]},
   "idna": {:hex, :idna, "1.2.0", "ac62ee99da068f43c50dc69acf700e03a62a348360126260e87f2b54eced86b2", [:rebar3], []},
+  "jose": {:hex, :jose, "1.8.0", "1ee027c5c0ff3922e3bfe58f7891509e8f87f771ba609ee859e623cc60237574", [:mix, :rebar3], [{:base64url, "~> 0.0.1", [hex: :base64url, optional: false]}]},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mime": {:hex, :mime, "1.0.1", "05c393850524767d13a53627df71beeebb016205eb43bfbd92d14d24ec7a1b51", [:mix], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
@@ -30,4 +33,5 @@
   "ranch": {:hex, :ranch, "1.2.1", "a6fb992c10f2187b46ffd17ce398ddf8a54f691b81768f9ef5f461ea7e28c762", [:make], []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:rebar, :make], []},
   "timex": {:hex, :timex, "3.1.4", "afe8e17970e7d90e60febcd10e4d80f73619b8c7ba24d9831c4f0e0c2ea75577", [:mix], [{:combine, "~> 0.7", [hex: :combine, optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, optional: false]}]},
-  "tzdata": {:hex, :tzdata, "0.5.9", "575be217b039057a47e133b72838cbe104fb5329b19906ea4e66857001c37edb", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, optional: false]}]}}
+  "tzdata": {:hex, :tzdata, "0.5.9", "575be217b039057a47e133b72838cbe104fb5329b19906ea4e66857001c37edb", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, optional: false]}]},
+  "uuid": {:hex, :uuid, "1.1.5", "96cb36d86ee82f912efea4d50464a5df606bf3f1163d6bdbb302d98474969369", [:mix], []}}

--- a/web/controllers/authenticate.ex
+++ b/web/controllers/authenticate.ex
@@ -2,7 +2,7 @@ defmodule Pairmotron.Plug.Authenticate do
   alias Pairmotron.Router.Helpers, as: Routes
   import Plug.Conn
 
-  alias Pairmotron.{Repo, User}
+  alias Pairmotron.User
 
   def init(opts) do
     opts
@@ -13,23 +13,13 @@ defmodule Pairmotron.Plug.Authenticate do
   end
 
   defp assign_current_user(conn = %Plug.Conn{}) do
-    current_user_id = current_assigned_user_id(conn) || Guardian.Plug.current_resource(conn)
-    assign_current_user(conn, current_user_id)
-  end
-  defp assign_current_user(conn, id) when is_integer(id) do
-    assign_current_user(conn, Repo.get(User, id))
+    current_user = conn.assigns[:current_user] || Guardian.Plug.current_resource(conn)
+    assign_current_user(conn, current_user)
   end
   defp assign_current_user(conn, user = %User{}) do
     assign(conn, :current_user, user)
   end
   defp assign_current_user(conn, _), do: redirect_to_sign_in(conn)
-
-  defp current_assigned_user_id(conn) do
-    case user = conn.assigns[:current_user] do
-      %User{} -> user.id
-      _ -> nil
-    end
-  end
 
   defp redirect_to_sign_in(conn) do
     conn

--- a/web/controllers/authenticate.ex
+++ b/web/controllers/authenticate.ex
@@ -13,7 +13,7 @@ defmodule Pairmotron.Plug.Authenticate do
   end
 
   defp assign_current_user(conn = %Plug.Conn{}) do
-    current_user_id = current_assigned_user_id(conn) || get_session(conn, :current_user_id)
+    current_user_id = current_assigned_user_id(conn) || Guardian.Plug.current_resource(conn)
     assign_current_user(conn, current_user_id)
   end
   defp assign_current_user(conn, id) when is_integer(id) do

--- a/web/router.ex
+++ b/web/router.ex
@@ -7,6 +7,8 @@ defmodule Pairmotron.Router do
     plug :fetch_flash
     plug :protect_from_forgery
     plug :put_secure_browser_headers
+    plug Guardian.Plug.VerifySession
+    plug Guardian.Plug.LoadResource
   end
 
   pipeline :authenticate do
@@ -15,6 +17,8 @@ defmodule Pairmotron.Router do
 
   pipeline :api do
     plug :accepts, ["json"]
+    plug Guardian.Plug.VerifyHeader
+    plug Guardian.Plug.LoadResource
   end
 
   scope "/", Pairmotron do


### PR DESCRIPTION
Adds token-based authentication.

Simplifies the Authenticate Plug because the User is retrieved from the database directly by Guardian whenever authentication occurs. This speeds up tests for authenticated routes slightly.

Closes #39 