### PR TITLE
Make project pages render clickable urls

### DIFF
--- a/test/controllers/project_controller_test.exs
+++ b/test/controllers/project_controller_test.exs
@@ -2,8 +2,8 @@ defmodule Pairmotron.ProjectControllerTest do
   use Pairmotron.ConnCase
 
   alias Pairmotron.Project
-  @valid_attrs %{description: "some content", name: "some content", url: "some content"}
-  @invalid_attrs %{}
+  @valid_attrs %{description: "some content", name: "some content", url: "http://example.org"}
+  @invalid_attrs %{url: "nothing"}
 
   def log_in(conn, user) do
     conn |> Plug.Conn.assign(:current_user, user)

--- a/test/models/project_test.exs
+++ b/test/models/project_test.exs
@@ -3,8 +3,8 @@ defmodule Pairmotron.ProjectTest do
 
   alias Pairmotron.Project
 
-  @valid_attrs %{name: "some content", url: "some content"}
-  @invalid_attrs %{}
+  @valid_attrs %{name: "some content", url: "http://example.org"}
+  @invalid_attrs %{url: "nothing"}
 
   test "changeset with valid attributes" do
     changeset = Project.changeset(%Project{}, @valid_attrs)

--- a/web/models/project.ex
+++ b/web/models/project.ex
@@ -18,5 +18,16 @@ defmodule Pairmotron.Project do
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, @required_params, @optional_params)
+    |> validate_url(:url)
+  end
+
+  def validate_url(changeset, field) do
+    validate_change changeset, field, fn _, url ->
+      case url |> URI.parse do
+        %URI{scheme: nil} -> [{field, "URL is missing the scheme. Include 'http://' or 'https://'."}]
+        %URI{host: nil} -> [{field, "URL is not valid."}]
+        _ -> []
+      end
+    end
   end
 end

--- a/web/templates/project/index.html.eex
+++ b/web/templates/project/index.html.eex
@@ -5,7 +5,6 @@
     <tr>
       <th>Name</th>
       <th>Description</th>
-      <th>Url</th>
 
       <th></th>
     </tr>
@@ -13,9 +12,14 @@
   <tbody>
 <%= for project <- @projects do %>
     <tr>
-      <td><%= project.name %></td>
+      <td>
+        <%= if project.url do %>
+          <%= link project.name, to: project.url %>
+        <%= else %>
+          <%= project.name %>
+        <%= end %>
+      </td>
       <td><%= project.description %></td>
-      <td><%= project.url %></td>
 
       <td class="text-right">
         <%= link "Show", to: project_path(@conn, :show, project), class: "btn btn-default btn-xs" %>

--- a/web/templates/project/show.html.eex
+++ b/web/templates/project/show.html.eex
@@ -4,17 +4,16 @@
 
   <li>
     <strong>Name:</strong>
-    <%= @project.name %>
+    <%= if @project.url do %>
+      <%= link @project.name, to: @project.url %>
+    <%= else %>
+      <%= @project.name %>
+    <%= end %>
   </li>
 
   <li>
     <strong>Description:</strong>
     <%= @project.description %>
-  </li>
-
-  <li>
-    <strong>Url:</strong>
-    <%= @project.url %>
   </li>
 
 </ul>


### PR DESCRIPTION
Add light url validation to projects.
Make templates render the name as a clickable link if it has a url.

Closes #37 

Project :index
<img width="723" alt="screen shot 2016-12-12 at 10 19 10 am" src="https://cloud.githubusercontent.com/assets/4420576/21104452/83763682-c054-11e6-985e-95543fea20da.png">

Project :show
<img width="731" alt="screen shot 2016-12-12 at 10 19 18 am" src="https://cloud.githubusercontent.com/assets/4420576/21104451/83750fc8-c054-11e6-9e84-c2eca992172d.png">

Project :edit
<img width="747" alt="screen shot 2016-12-12 at 10 19 25 am" src="https://cloud.githubusercontent.com/assets/4420576/21104450/8373ef76-c054-11e6-9e37-59c01ed11e54.png">

And the :index with a project without a url
<img width="715" alt="screen shot 2016-12-12 at 10 22 14 am" src="https://cloud.githubusercontent.com/assets/4420576/21104531/e6672aee-c054-11e6-8c77-1cd5289093e9.png">

