### PR TITLE
Fix error when logging in with unknown email

### DIFF
--- a/test/controllers/session_controller_test.exs
+++ b/test/controllers/session_controller_test.exs
@@ -32,8 +32,7 @@ defmodule Pairmotron.SessionControllerTest do
   end
 
   test "logging in with an email that doesn't exist fails with error message", %{conn: conn} do
-    %User{email: _user_email, password: user_pw} = insert(:user)
-    params = %{"user" => %{email: "unknown email", password: user_pw}}
+    params = %{"user" => %{email: "unknown email", password: "password"}}
     conn = post conn, session_path(conn, :create), params
     assert html_response(conn, 200) =~ "Login"
     assert html_response(conn, 200) =~ "Name and/or password are incorrect"

--- a/web/controllers/session_controller.ex
+++ b/web/controllers/session_controller.ex
@@ -34,10 +34,8 @@ defmodule Pairmotron.SessionController do
     |> render("new.html", changeset: User.changeset(%User{}))
   end
 
-  defp sign_in(_user, %{"password" => nil}, conn) do
-    conn |> bad_sign_in
-  end
-
+  defp sign_in(nil, _, conn), do: bad_sign_in(conn)
+  defp sign_in(_, %{"password" => nil}, conn), do: bad_sign_in(conn)
   defp sign_in(user, %{"password" => password}, conn) do
     if Comeonin.Bcrypt.checkpw(password, user.password_hash) do
       conn


### PR DESCRIPTION
Logging in with an email that doesn't exist was resulting in an
unhandled exception. The test case around this did not catch it because
the user factory generates a nil password, which is caught by a function
head that handled a nil password correctly.