### PR TITLE
Remove ability to delete other users

### DIFF
--- a/lib/abilities.ex
+++ b/lib/abilities.ex
@@ -4,5 +4,7 @@ defimpl Canada.Can, for: Pairmotron.User do
   def can?(%User{id: user_id}, action, %PairRetro{user_id: user_id})
     when action in [:edit, :update, :show, :delete], do: true
 
+  def can?(%User{id: user_id}, :delete, %User{id: user_id}), do: true
+
   def can?(%User{}, _, _), do: false
 end

--- a/lib/abilities.ex
+++ b/lib/abilities.ex
@@ -4,7 +4,8 @@ defimpl Canada.Can, for: Pairmotron.User do
   def can?(%User{id: user_id}, action, %PairRetro{user_id: user_id})
     when action in [:edit, :update, :show, :delete], do: true
 
-  def can?(%User{id: user_id}, :delete, %User{id: user_id}), do: true
+  def can?(%User{id: user_id}, action, %User{id: user_id})
+    when action in [:edit, :update, :delete], do: true
 
   def can?(%User{}, _, _), do: false
 end

--- a/test/controllers/user_controller_test.exs
+++ b/test/controllers/user_controller_test.exs
@@ -88,11 +88,17 @@ defmodule Pairmotron.UserControllerTest do
       assert html_response(conn, 200) =~ "Edit user"
     end
 
-    test "deletes chosen resource", %{conn: conn} do
-      user = insert(:user)
+    test "deletes the logged in user", %{conn: conn, logged_in_user: user} do
       conn = delete conn, user_path(conn, :delete, user)
       assert redirected_to(conn) == user_path(conn, :index)
       refute Repo.get(User, user.id)
+    end
+
+    test "does not delete a non-logged in user", %{conn: conn} do
+      user = insert(:user)
+      conn = delete conn, user_path(conn, :delete, user)
+      assert redirected_to(conn) == user_path(conn, :index)
+      assert Repo.get(User, user.id)
     end
   end
 end

--- a/test/controllers/user_controller_test.exs
+++ b/test/controllers/user_controller_test.exs
@@ -4,8 +4,7 @@ defmodule Pairmotron.UserControllerTest do
   alias Pairmotron.User
   import Pairmotron.TestHelper, only: [log_in: 2]
 
-  @valid_attrs %{email: "some content", name: "some content", password_hash: "test"}
-  @valid_reg_attrs %{email: "email", name: "name", password: "password", password_confirmation: "password"}
+  @valid_attrs %{email: "email", name: "name", password: "password", password_confirmation: "password"}
   @invalid_attrs %{}
 
   test "redirects to sign-in when not logged in", %{conn: conn} do
@@ -32,7 +31,7 @@ defmodule Pairmotron.UserControllerTest do
     end
 
     test "creates resource and redirects when data is valid", %{conn: conn} do
-      conn = post conn, user_path(conn, :create), user: @valid_reg_attrs
+      conn = post conn, user_path(conn, :create), user: @valid_attrs
       assert redirected_to(conn) == user_path(conn, :index)
       assert Repo.get_by(User, %{email: "email", name: "name"})
     end
@@ -54,35 +53,34 @@ defmodule Pairmotron.UserControllerTest do
       end
     end
 
-    test "renders form for editing chosen resource", %{conn: conn} do
-      user = insert(:user)
+    test "renders form for editing own resource", %{conn: conn, logged_in_user: user} do
       conn = get conn, user_path(conn, :edit, user)
       assert html_response(conn, 200) =~ "Edit user"
     end
 
-    test "updates chosen resource and redirects when data is valid", %{conn: conn} do
+    test "redirects when editing other users resource", %{conn: conn} do
       user = insert(:user)
-      updated_attr = %{name: "new_name", email: "new_email"}
-      conn = put conn, user_path(conn, :update, user), user: updated_attr
+      conn = get conn, user_path(conn, :edit, user)
+      assert redirected_to(conn) == user_path(conn, :index)
+    end
+
+    test "updates user and redirects if user is logged in user", %{conn: conn, logged_in_user: user} do
+      conn = put conn, user_path(conn, :update, user), user: @valid_attrs
       assert redirected_to(conn) == user_path(conn, :show, user)
-      assert Repo.get_by(User, updated_attr)
+      expected_attrs = Map.drop(@valid_attrs, [:password, :password_confirmation])
+      assert Repo.get_by(User, expected_attrs)
     end
 
-    test "updates password if that user is the logged in user", %{conn: conn, logged_in_user: user} do
-      updated_attr = %{password: "new_password", password_confirmation: "new_password"}
-      conn = put conn, user_path(conn, :update, user), user: updated_attr
-      assert redirected_to(conn) == user_path(conn, :show, user)
-    end
-
-    test "does not update password of a user that is not logged in", %{conn: conn} do
-      other_user = insert(:user)
-      updated_attr = %{password: "new_password", password_confirmation: "new_password"}
-      conn = put conn, user_path(conn, :update, other_user), user: updated_attr
-      assert html_response(conn, 200) =~ "Edit user"
-    end
-
-    test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
+    test "does not update user if user is not logged in user", %{conn: conn} do
       user = insert(:user)
+      conn = put conn, user_path(conn, :update, user), user: @valid_attrs
+      assert redirected_to(conn) == user_path(conn, :index)
+      expected_attrs = Map.drop(@valid_attrs, [:password, :password_confirmation])
+      refute Repo.get_by(User, expected_attrs)
+    end
+
+    test "does not update chosen resource and renders errors when data is invalid", 
+      %{conn: conn, logged_in_user: user} do
       conn = log_in(conn, user)
       conn = put conn, user_path(conn, :update, user), user: %{name: ""}
       assert html_response(conn, 200) =~ "Edit user"

--- a/web/controllers/user_controller.ex
+++ b/web/controllers/user_controller.ex
@@ -4,7 +4,7 @@ defmodule Pairmotron.UserController do
   alias Pairmotron.User
   import Pairmotron.ControllerHelpers
 
-  plug :load_and_authorize_resource, model: User, only: [:delete]
+  plug :load_and_authorize_resource, model: User, only: [:edit, :update, :delete]
 
   def index(conn, _params) do
     users = Repo.all(User)
@@ -34,33 +34,30 @@ defmodule Pairmotron.UserController do
     render(conn, "show.html", user: user)
   end
 
-  def edit(conn, %{"id" => id}) do
-    user = Repo.get!(User, id)
-    changeset = User.changeset(user)
-    render(conn, "edit.html", user: user, changeset: changeset)
-  end
-
-  def update(conn, %{"id" => id, "user" => user_params}) do
-    user = Repo.get!(User, id)
-    changeset = User.changeset(user, user_params)
-
-    if current_assigned_user_id(conn) != id && changeset.changes[:password] do
-      conn
-      |> put_flash(:info, "You cannot change the password for a different user")
-      |> render("edit.html", user: user, changeset: changeset)
+  def edit(conn, _params) do
+    if conn.assigns.authorized do
+      user = conn.assigns.user
+      changeset = User.changeset(user)
+      render(conn, "edit.html", user: user, changeset: changeset)
     else
-      _update(conn, user, changeset)
+      redirect_not_authorized(conn, user_path(conn, :index))
     end
   end
 
-  defp _update(conn, user, changeset) do
-    case Repo.update(changeset) do
-      {:ok, user} ->
-        conn
-        |> put_flash(:info, "User updated successfully.")
-        |> redirect(to: user_path(conn, :show, user))
-      {:error, changeset} ->
-        render(conn, "edit.html", user: user, changeset: changeset)
+  def update(conn, %{"user" => user_params}) do
+    if conn.assigns.authorized do
+      user = conn.assigns.user
+      changeset = User.changeset(user, user_params)
+      case Repo.update(changeset) do
+        {:ok, user} ->
+          conn
+          |> put_flash(:info, "User updated successfully.")
+          |> redirect(to: user_path(conn, :show, user))
+        {:error, changeset} ->
+          render(conn, "edit.html", user: user, changeset: changeset)
+      end
+    else
+      redirect_not_authorized(conn, user_path(conn, :index))
     end
   end
 
@@ -73,13 +70,6 @@ defmodule Pairmotron.UserController do
       |> redirect(to: user_path(conn, :index))
     else
       redirect_not_authorized(conn, user_path(conn, :index))
-    end
-  end
-
-  defp current_assigned_user_id(conn) do
-    case user = conn.assigns[:current_user] do
-      %User{} -> Integer.to_string(user.id)
-      _ -> nil
     end
   end
 end

--- a/web/controllers/user_controller.ex
+++ b/web/controllers/user_controller.ex
@@ -2,6 +2,9 @@ defmodule Pairmotron.UserController do
   use Pairmotron.Web, :controller
 
   alias Pairmotron.User
+  import Pairmotron.ControllerHelpers
+
+  plug :load_and_authorize_resource, model: User, only: [:delete]
 
   def index(conn, _params) do
     users = Repo.all(User)
@@ -61,16 +64,16 @@ defmodule Pairmotron.UserController do
     end
   end
 
-  def delete(conn, %{"id" => id}) do
-    user = Repo.get!(User, id)
+  def delete(conn, _params) do
+    if conn.assigns.authorized do
+      Repo.delete!(conn.assigns.user)
 
-    # Here we use delete! (with a bang) because we expect
-    # it to always work (and if it does not, it will raise).
-    Repo.delete!(user)
-
-    conn
-    |> put_flash(:info, "User deleted successfully.")
-    |> redirect(to: user_path(conn, :index))
+      conn
+      |> put_flash(:info, "User deleted successfully.")
+      |> redirect(to: user_path(conn, :index))
+    else
+      redirect_not_authorized(conn, user_path(conn, :index))
+    end
   end
 
   defp current_assigned_user_id(conn) do

--- a/web/templates/user/index.html.eex
+++ b/web/templates/user/index.html.eex
@@ -18,8 +18,8 @@
 
       <td class="text-right">
         <%= link "Show", to: user_path(@conn, :show, user), class: "btn btn-default btn-xs" %>
-        <%= link "Edit", to: user_path(@conn, :edit, user), class: "btn btn-default btn-xs" %>
         <%= if @conn.assigns.current_user.id == user.id do %>
+          <%= link "Edit", to: user_path(@conn, :edit, user), class: "btn btn-default btn-xs" %>
           <%= link "Delete", to: user_path(@conn, :delete, user), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs" %>
         <% end %>
       </td>

--- a/web/templates/user/index.html.eex
+++ b/web/templates/user/index.html.eex
@@ -19,7 +19,9 @@
       <td class="text-right">
         <%= link "Show", to: user_path(@conn, :show, user), class: "btn btn-default btn-xs" %>
         <%= link "Edit", to: user_path(@conn, :edit, user), class: "btn btn-default btn-xs" %>
-        <%= link "Delete", to: user_path(@conn, :delete, user), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs" %>
+        <%= if @conn.assigns.current_user.id == user.id do %>
+          <%= link "Delete", to: user_path(@conn, :delete, user), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs" %>
+        <% end %>
       </td>
     </tr>
 <% end %>

--- a/web/templates/user/show.html.eex
+++ b/web/templates/user/show.html.eex
@@ -8,11 +8,6 @@
   </li>
 
   <li>
-    <strong>Email:</strong>
-    <%= @user.email %>
-  </li>
-
-  <li>
     <strong>Active:</strong>
     <%= @user.active %>
   </li>


### PR DESCRIPTION
Prevents users from deleting other users. Forces the user to authorize using canary for the delete action of the user controller, and also hides the delete button for all users in the user index that are not the current user.

Closes #50 