### PR TITLE
Make login redirect to /pairs when user in session

### DIFF
--- a/test/controllers/session_controller_test.exs
+++ b/test/controllers/session_controller_test.exs
@@ -2,10 +2,17 @@ defmodule Pairmotron.SessionControllerTest do
   use Pairmotron.ConnCase
 
   alias Pairmotron.User
+  import Pairmotron.TestHelper, only: [guardian_log_in: 2]
 
   test "renders form for new resources", %{conn: conn} do
     conn = get conn, session_path(conn, :new)
     assert html_response(conn, 200) =~ "Login"
+  end
+
+  test "redirects to /pairs when user is logged in", %{conn: conn} do
+    conn = conn |> guardian_log_in(insert(:user))
+    conn = get conn, session_path(conn, :new)
+    assert redirected_to(conn) == page_path(conn, :index)
   end
 
   test "logging in with proper credentials redirects to /pairs", %{conn: conn} do

--- a/test/support/test_helper.ex
+++ b/test/support/test_helper.ex
@@ -1,9 +1,20 @@
 defmodule Pairmotron.TestHelper do
 
   alias Pairmotron.{Pair, PairRetro, Repo, UserPair}
+  require Phoenix.ConnTest
+  @endpoint Pairmotron.Endpoint
 
   def log_in(conn, user) do
     conn |> Plug.Conn.assign(:current_user, user)
+  end
+
+  def guardian_log_in(conn, user) do
+    conn
+    |> Phoenix.ConnTest.bypass_through(Pairmotron.Router, [:browser])
+    |> Phoenix.ConnTest.get("/")
+    |> Guardian.Plug.sign_in(user, :token)
+    |> Plug.Conn.send_resp(200, "Session Flushed")
+    |> Phoenix.ConnTest.recycle()
   end
 
   def create_pair(users) do

--- a/web/controllers/session_controller.ex
+++ b/web/controllers/session_controller.ex
@@ -6,7 +6,11 @@ defmodule Pairmotron.SessionController do
   plug :scrub_params, "user" when action in [:create]
 
   def new(conn, _params) do
-    render conn, changeset: User.changeset(%User{})
+    if Guardian.Plug.current_resource(conn) do
+      conn |> redirect(to: page_path(conn, :index))
+    else
+      render conn, changeset: User.changeset(%User{})
+    end
   end
 
   def create(conn, %{"user" => %{"email" => nil}}) do


### PR DESCRIPTION
Currently, if the user is logged in, and visits the "/" route, they are greeted by the login screen, with no indication that they are actually logged in. This doesn't quite make sense, so in this case, the user is redirected to the /pairs route.

Closes #44 