### PR TITLE
35: Add roles and admin functions

### DIFF
--- a/lib/abilities.ex
+++ b/lib/abilities.ex
@@ -1,11 +1,18 @@
 defimpl Canada.Can, for: Pairmotron.User do
-  alias Pairmotron.{PairRetro, User}
+  alias Pairmotron.{PairRetro, Role, User}
 
   def can?(%User{id: user_id}, action, %PairRetro{user_id: user_id})
     when action in [:edit, :update, :show, :delete], do: true
 
   def can?(%User{id: user_id}, action, %User{id: user_id})
     when action in [:edit, :update, :delete], do: true
+
+  def can?(%User{role_id: role_id}, _, _) when not is_nil(role_id) do
+    case Pairmotron.Repo.get(Role, role_id) do
+      nil -> false
+      role -> role.is_admin
+    end
+  end
 
   def can?(%User{}, _, _), do: false
 end

--- a/priv/repo/migrations/20170107183316_create_role.exs
+++ b/priv/repo/migrations/20170107183316_create_role.exs
@@ -1,0 +1,19 @@
+defmodule Pairmotron.Repo.Migrations.CreateRole do
+  use Ecto.Migration
+
+  def change do
+    create table(:roles) do
+      add :name, :string
+      add :is_admin, :boolean, default: false, null: false
+
+      timestamps()
+    end
+
+    create unique_index(:roles, [:name])
+
+    alter table(:users) do
+      add :role_id, references(:roles, on_delete: :nilify_all)
+    end
+
+  end
+end

--- a/test/controllers/user_controller_test.exs
+++ b/test/controllers/user_controller_test.exs
@@ -99,4 +99,34 @@ defmodule Pairmotron.UserControllerTest do
       assert Repo.get(User, user.id)
     end
   end
+
+  describe "as admin" do
+    setup do
+      user = insert(:user_admin)
+      conn = build_conn
+        |> log_in(user)
+      {:ok, [conn: conn, logged_in_user: user]}
+    end
+
+    test "renders form for editing other user", %{conn: conn} do
+      user = insert(:user)
+      conn = get conn, user_path(conn, :edit, user)
+      assert html_response(conn, 200) =~ "Edit user"
+    end
+
+    test "updates other user and redirects", %{conn: conn} do
+      user = insert(:user)
+      conn = put conn, user_path(conn, :update, user), user: @valid_attrs
+      assert redirected_to(conn) == user_path(conn, :show, user)
+      expected_attrs = Map.drop(@valid_attrs, [:password, :password_confirmation])
+      assert Repo.get_by(User, expected_attrs)
+    end
+
+    test "deletes other user", %{conn: conn} do
+      user = insert(:user)
+      conn = delete conn, user_path(conn, :delete, user)
+      assert redirected_to(conn) == user_path(conn, :index)
+      refute Repo.get(User, user.id)
+    end
+  end
 end

--- a/test/models/role_test.exs
+++ b/test/models/role_test.exs
@@ -1,0 +1,18 @@
+defmodule Pairmotron.RoleTest do
+  use Pairmotron.ModelCase
+
+  alias Pairmotron.Role
+
+  @valid_attrs %{is_admin: true, name: "some content"}
+  @invalid_attrs %{}
+
+  test "changeset with valid attributes" do
+    changeset = Role.changeset(%Role{}, @valid_attrs)
+    assert changeset.valid?
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = Role.changeset(%Role{}, @invalid_attrs)
+    refute changeset.valid?
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -2,7 +2,7 @@ defmodule Pairmotron.Factory do
   # with Ecto
   use ExMachina.Ecto, repo: Pairmotron.Repo
 
-  alias Pairmotron.{Project, User}
+  alias Pairmotron.{Project, Role, User}
 
   def user_factory do
     %User{
@@ -10,6 +10,16 @@ defmodule Pairmotron.Factory do
       email: sequence(:email, &"email-#{&1}@example.com"),
       active: true,
       password_hash: "12345678"
+    }
+  end
+
+  def user_admin_factory do
+    %User{
+      name: sequence(:first_name, &"name #{&1}"),
+      email: sequence(:email, &"email-#{&1}@example.com"),
+      active: true,
+      password_hash: "12345678",
+      role: build(:role, is_admin: true)
     }
   end
 
@@ -21,6 +31,13 @@ defmodule Pairmotron.Factory do
       password: "12345678",
       password_confirmation: "12345678",
       password_hash: Comeonin.Bcrypt.hashpwsalt("12345678")
+    }
+  end
+
+  def role_factory do
+    %Role{
+      name: sequence(:role_name, &"role #{&1}"),
+      is_admin: false
     }
   end
 

--- a/web/controllers/controller_helpers.ex
+++ b/web/controllers/controller_helpers.ex
@@ -44,4 +44,18 @@ defmodule Pairmotron.ControllerHelpers do
       _ -> 0
     end
   end
+
+  @doc """
+  Given a user, returns true if that user has a role and that role's
+  is_admin property is true. Otherwise, returns false.
+  """
+  def is_admin?(user) do
+    cond do
+      is_nil(user.role_id) -> false
+      Ecto.assoc_loaded?(user.role) ->
+        user.role.is_admin
+      true ->
+        Pairmotron.Repo.get!(Pairmotron.Role, user.role_id).is_admin
+    end
+  end
 end

--- a/web/controllers/pair_retro_controller.ex
+++ b/web/controllers/pair_retro_controller.ex
@@ -22,7 +22,7 @@ defmodule Pairmotron.PairRetroController do
   def create(conn, %{"pair_retro" => pair_retro_params}) do
     user_id = parameter_as_integer(pair_retro_params, "user_id")
     current_user = conn.assigns[:current_user]
-    if current_user.id == user_id || user_id == 0 do
+    if current_user.id == user_id || user_id == 0 || is_admin?(current_user) do
       earliest_pair_date = earliest_pair_date_from_params(pair_retro_params)
       changeset = PairRetro.changeset(%PairRetro{}, pair_retro_params, earliest_pair_date)
       case Repo.insert(changeset) do

--- a/web/models/role.ex
+++ b/web/models/role.ex
@@ -1,0 +1,22 @@
+defmodule Pairmotron.Role do
+  use Pairmotron.Web, :model
+
+  schema "roles" do
+    field :name, :string
+    field :is_admin, :boolean, default: false
+
+    has_many :users, Pairmotron.User
+
+    timestamps()
+  end
+
+  @doc """
+  Builds a changeset based on the `struct` and `params`.
+  """
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:name, :is_admin])
+    |> validate_required([:name, :is_admin])
+    |> unique_constraint(:name)
+  end
+end

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -10,6 +10,7 @@ defmodule Pairmotron.User do
     field :password_confirmation, :string, virtual: true
     field :password_hash, :string
 
+    belongs_to :role, Pairmotron.Role
     has_many :pair_retros, Pairmotron.PairRetro
 
     timestamps()


### PR DESCRIPTION
Adds the roles table. Users can have Roles, which describe what they are able to do in the app. As a part of this PR, Roles have a name and a boolean value indicating whether they are admins or not.

Currently admins' only special abilities are that they can perform all of the functions for users and retrospectives that are currently only modifiable when they are associated with the logged in user.

The proposed logic to make the first user an admin by default, as specified in the original issue, has been decided against. Although it might make someone first using the app's life a bit easier, it might also be unintuitive from a development standpoint. A better option to make sure that an admin is setup initially would be to either seed an admin user and an admin role, or only the role. Anyone have thoughts?

- [x] Figure out what to seed.

I was considering adding the ability for admin's to set the roles of other users, but ultimately decided against it for this PR. The implementation details are a bit more nuanced than they first seem, as there are a few ways to do it with varying levels of db performance and complexity. Ultimately, this PR works as is, but requires some manual db intervention to setup roles and assign users roles.

- [ ] Make an issue to add role selection to the UI.

closes #35 