### PR TITLE
Preload role for current_user

### DIFF
--- a/web/controllers/authenticate.ex
+++ b/web/controllers/authenticate.ex
@@ -3,6 +3,7 @@ defmodule Pairmotron.Plug.Authenticate do
   import Plug.Conn
 
   alias Pairmotron.User
+  alias Pairmotron.Repo
 
   def init(opts) do
     opts
@@ -17,7 +18,7 @@ defmodule Pairmotron.Plug.Authenticate do
     assign_current_user(conn, current_user)
   end
   defp assign_current_user(conn, user = %User{}) do
-    assign(conn, :current_user, user)
+    assign(conn, :current_user, user |> Repo.preload(:role))
   end
   defp assign_current_user(conn, _), do: redirect_to_sign_in(conn)
 

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -19,7 +19,7 @@ defmodule Pairmotron.User do
   @minimum_password_length 8
 
   @required_params ~w(name email)
-  @optional_params ~w(password password_confirmation active)
+  @optional_params ~w(password password_confirmation active role_id)
 
   @doc """
   Builds a changeset based on the `struct` and `params`.

--- a/web/templates/user/index.html.eex
+++ b/web/templates/user/index.html.eex
@@ -16,7 +16,7 @@
 
       <td class="text-right">
         <%= link "Show", to: user_path(@conn, :show, user), class: "btn btn-default btn-xs" %>
-        <%= if @conn.assigns.current_user.id == user.id do %>
+        <%= if @conn.assigns.current_user.id == user.id || is_admin?(@conn.assigns.current_user) do %>
           <%= link "Edit", to: user_path(@conn, :edit, user), class: "btn btn-default btn-xs" %>
           <%= link "Delete", to: user_path(@conn, :delete, user), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs" %>
         <% end %>

--- a/web/views/view_helper.ex
+++ b/web/views/view_helper.ex
@@ -1,0 +1,11 @@
+defmodule Pairmotron.ViewHelpers do
+  @doc """
+  Given a user, returns true if that user has a role and that role's
+  is_admin property is true. Errors if the user's role is not loaded
+  and the user has a role. This is to prevent calling the database in
+  a view.
+  """
+  def is_admin?(user) do
+    user.role_id && user.role.is_admin
+  end
+end

--- a/web/web.ex
+++ b/web/web.ex
@@ -54,6 +54,8 @@ defmodule Pairmotron.Web do
       import Pairmotron.Router.Helpers
       import Pairmotron.ErrorHelpers
       import Pairmotron.Gettext
+
+      import Pairmotron.ViewHelpers
     end
   end
 


### PR DESCRIPTION
The role of the user is used enough for administrative purposes that it makes sense to preload it whenever we authorize the user.

This PR causes the role to be preloaded whenever assigning the current_user during authorization.

This PR also uses this in the users view to allow the edit and delete buttons to appear around any user if the current_user is an admin.