### PR TITLE
Fix current retro display bug in page :show

### DIFF
--- a/test/controllers/page_controller_test.exs
+++ b/test/controllers/page_controller_test.exs
@@ -9,61 +9,55 @@ defmodule Pairmotron.PageControllerTest do
     assert redirected_to(conn) == session_path(conn, :new)
   end
 
-  test "lists one active user", %{conn: conn} do
-    user = insert(:user)
-    conn = conn
-      |> log_in(user)
-      |> get("/pairs")
-    assert html_response(conn, 200) =~ user.name
-  end
+  describe "while authenticated" do
+    setup do
+      user = insert(:user)
+      conn = build_conn
+        |> log_in(user)
+      {:ok, [conn: conn, logged_in_user: user]}
+    end
 
-  test "does not list an inactive user", %{conn: conn} do
-    user = insert(:user, active: false)
-    conn = conn
-      |> log_in(user)
-      |> get("/pairs")
-    refute html_response(conn, 200) =~ user.name
-  end
+    test "lists one active user", %{conn: conn, logged_in_user: user} do
+      conn = get(conn, "/pairs")
+      assert html_response(conn, 200) =~ user.name
+    end
 
-  test "pairs two users together", %{conn: conn} do
-    [user1, user2] = insert_pair(:user)
-    conn = conn
-      |> log_in(user1)
-      |> get("/pairs")
-    assert html_response(conn, 200) =~ user1.name
-    assert html_response(conn, 200) =~ user2.name
-  end
+    test "does not list an inactive user", %{conn: conn} do
+      user = insert(:user, active: false)
+      conn = get(conn, "/pairs")
+      refute html_response(conn, 200) =~ user.name
+    end
 
-  test "does not re-pair after the first pair has been made", %{conn: conn} do
-    paired_users = [user1, user2] = insert_pair(:user)
-    create_pair(paired_users)
-    new_user = insert(:user)
-    conn = conn
-      |> log_in(new_user)
-      |> get("/pairs")
-    assert html_response(conn, 200) =~ user1.name
-    assert html_response(conn, 200) =~ user2.name
-    refute html_response(conn, 200) =~ new_user.name
-  end
+    test "pairs two users together", %{conn: conn, logged_in_user: user1} do
+      user2 = insert(:user)
+      conn = get(conn, "/pairs")
+      assert html_response(conn, 200) =~ user1.name
+      assert html_response(conn, 200) =~ user2.name
+    end
 
-  test "does not pairify for a week that is not current", %{conn: conn} do
-    [user1, user2] = insert_pair(:user)
-    conn = log_in(conn, user1)
-    conn = get conn, page_path(conn, :show, 1999, 1)
-    refute html_response(conn, 200) =~ user1.name
-    refute html_response(conn, 200) =~ user2.name
-  end
+    test "displays link to retro :create for a pair that has no retrospective" do
+    end
 
-  test "repairifying deletes current pairs and redirects to show", %{conn: conn} do
-    {year, week} = Timex.iso_week(Timex.today)
-    paired_users = [user1, user2] = insert_pair(:user)
-    create_pair(paired_users)
+    test "does not re-pair after the first pair has been made", %{conn: conn, logged_in_user: user} do
+      create_pair([user])
+      new_user = insert(:user)
+      conn = get(conn, "/pairs")
+      assert html_response(conn, 200) =~ user.name
+      refute html_response(conn, 200) =~ new_user.name
+    end
 
-    conn = log_in(conn, user1)
-    conn = delete conn, page_path(conn, :delete, year, week)
-    assert redirected_to(conn) == page_path(conn, :show, year, week)
+    test "does not pairify for a week that is not current", %{conn: conn, logged_in_user: user} do
+      conn = get conn, page_path(conn, :show, 1999, 1)
+      refute html_response(conn, 200) =~ user.name
+    end
 
-    refute Repo.get_by(UserPair, %{user_id: user1.id})
-    refute Repo.get_by(UserPair, %{user_id: user2.id})
+    test "repairifying deletes current pairs and redirects to show", %{conn: conn, logged_in_user: user} do
+      {year, week} = Timex.iso_week(Timex.today)
+      create_pair([user])
+      conn = delete conn, page_path(conn, :delete, year, week)
+      assert redirected_to(conn) == page_path(conn, :show, year, week)
+      refute Repo.get_by(UserPair, %{user_id: user.id})
+    end
+
   end
 end

--- a/test/controllers/pair_retro_controller_test.exs
+++ b/test/controllers/pair_retro_controller_test.exs
@@ -2,7 +2,8 @@ defmodule Pairmotron.PairRetroControllerTest do
   use Pairmotron.ConnCase
 
   alias Pairmotron.PairRetro
-  import Pairmotron.TestHelper, only: [log_in: 2, create_pair: 1, create_pair: 3, create_retro: 2]
+  import Pairmotron.TestHelper,
+    only: [log_in: 2, create_pair: 1, create_pair: 3, create_retro: 2, create_pair_and_retro: 1]
 
   @valid_attrs %{subject: "some content", reflection: "some content", pair_date: Timex.today}
   @invalid_attrs %{}
@@ -10,12 +11,6 @@ defmodule Pairmotron.PairRetroControllerTest do
   test "redirects to sign-in when not logged in", %{conn: conn} do
     conn = get conn, user_path(conn, :index)
     assert redirected_to(conn) == session_path(conn, :new)
-  end
-
-  defp create_pair_and_retro(user) do
-    pair = create_pair([user])
-    retro = create_retro(user, pair)
-    {pair, retro}
   end
 
   defp create_user_and_pair_and_retro() do

--- a/test/support/test_helper.ex
+++ b/test/support/test_helper.ex
@@ -54,4 +54,10 @@ defmodule Pairmotron.TestHelper do
                                           Timex.today)
     Repo.insert!(retro_changeset)
   end
+
+  def create_pair_and_retro(user) do
+    pair = create_pair([user])
+    retro = create_retro(user, pair)
+    {pair, retro}
+  end
 end

--- a/web/controllers/page_controller.ex
+++ b/web/controllers/page_controller.ex
@@ -19,6 +19,7 @@ defmodule Pairmotron.PageController do
     {year, _} = y |> Integer.parse
     {week, _} = w |> Integer.parse
     pairs = fetch_or_gen(year, week)
+    conn = assign_current_user_pair_retro_for_week(conn, year, week)
     render conn, "index.html", pairs: pairs, year: year, week: week
   end
 


### PR DESCRIPTION
Currently, if the current user has submitted a retrospective for a pair, that retrospective is not assigned to the conn, and so isn't visible on the page :show route like it is for the page :index route. This PR fixes this.