### PR TITLE
Add groups

### DIFF
--- a/lib/abilities.ex
+++ b/lib/abilities.ex
@@ -1,5 +1,7 @@
 defimpl Canada.Can, for: Pairmotron.User do
-  alias Pairmotron.{PairRetro, User}
+  alias Pairmotron.{Group, PairRetro, User}
+
+  def can?(%User{is_admin: true}, _, _), do: true
 
   def can?(%User{id: user_id}, action, %PairRetro{user_id: user_id})
     when action in [:edit, :update, :show, :delete], do: true
@@ -7,7 +9,8 @@ defimpl Canada.Can, for: Pairmotron.User do
   def can?(%User{id: user_id}, action, %User{id: user_id})
     when action in [:edit, :update, :delete], do: true
 
-  def can?(%User{is_admin: true}, _, _), do: true
+  def can?(%User{id: user_id}, action, %Group{owner_id: user_id})
+    when action in [:edit, :update, :delete], do: true
 
   def can?(%User{}, _, _), do: false
 end

--- a/priv/repo/migrations/20170122001358_create_group.exs
+++ b/priv/repo/migrations/20170122001358_create_group.exs
@@ -1,0 +1,24 @@
+defmodule Pairmotron.Repo.Migrations.CreateGroup do
+  use Ecto.Migration
+
+  def change do
+    create table(:groups) do
+      add :name, :string
+      add :owner_id, references(:users)
+
+      timestamps()
+    end
+
+    create unique_index(:groups, [:name])
+
+    create table(:users_groups) do
+      add :user_id, references(:users, on_delete: :delete_all)
+      add :group_id, references(:groups, on_delete: :delete_all)
+
+      timestamps()
+    end
+
+    create unique_index(:users_groups, [:user_id, :group_id])
+
+  end
+end

--- a/test/controllers/group_controller_test.exs
+++ b/test/controllers/group_controller_test.exs
@@ -30,14 +30,11 @@ defmodule Pairmotron.GroupControllerTest do
       assert html_response(conn, 200) =~ "New group"
     end
 
-    test "creates resource and redirects when data is valid", %{conn: conn} do
-      conn = post conn, group_path(conn, :create), group: @valid_attrs
+    test "creates resource and redirects when data is valid", %{conn: conn, logged_in_user: user} do
+      attrs = Map.merge(@valid_attrs, %{owner_id: Integer.to_string(user.id)})
+      conn = post conn, group_path(conn, :create), group: attrs
       assert redirected_to(conn) == group_path(conn, :index)
-      assert Repo.get_by(Group, @valid_attrs)
-    end
-
-    test "created resource's owner is the currently logged in user", %{conn: conn} do
-      #TODO
+      assert Repo.get_by(Group, attrs)
     end
 
     test "does not create resource and renders errors when data is invalid", %{conn: conn} do
@@ -57,54 +54,79 @@ defmodule Pairmotron.GroupControllerTest do
       end
     end
 
-    test "renders form for editing chosen resource", %{conn: conn} do
-      group = Repo.insert! %Group{}
+    test "renders form for editing chosen resource", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, owner: user)
       conn = get conn, group_path(conn, :edit, group)
       assert html_response(conn, 200) =~ "Edit group"
     end
 
     test "does not allow editing a group not owned by logged in user", %{conn: conn} do
-      #TODO
+      group = insert(:group)
+      conn = get conn, group_path(conn, :edit, group)
+      assert redirected_to(conn) == group_path(conn, :index)
     end
 
-    test "admin may edit a group not owned by admin", %{conn: conn} do
-      #TODO
-    end
-
-    test "updates chosen resource and redirects when data is valid", %{conn: conn} do
-      group = Repo.insert! %Group{}
+    test "updates chosen resource and redirects when data is valid", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, owner: user)
       conn = put conn, group_path(conn, :update, group), group: @valid_attrs
       assert redirected_to(conn) == group_path(conn, :show, group)
       assert Repo.get_by(Group, @valid_attrs)
     end
 
     test "does not allow updating a group not owned by logged in user", %{conn: conn} do
-      #TODO
+      group = insert(:group)
+      conn = put conn, group_path(conn, :update, group), group: @valid_attrs
+      assert redirected_to(conn) == group_path(conn, :index)
+      refute Repo.get_by(Group, @valid_attrs)
     end
 
-    test "admin may update a group not owned by admin", %{conn: conn} do
-      #TODO
-    end
-
-    test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
-      group = Repo.insert! %Group{}
+    test "does not update chosen resource and renders errors when data is invalid", %{conn: conn, logged_in_user: user} do
+      group = Repo.insert! %Group{owner: user}
       conn = put conn, group_path(conn, :update, group), group: @invalid_attrs
       assert html_response(conn, 200) =~ "Edit group"
     end
 
-    test "deletes chosen resource", %{conn: conn} do
-      group = Repo.insert! %Group{}
+    test "deletes chosen resource", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, owner: user)
       conn = delete conn, group_path(conn, :delete, group)
       assert redirected_to(conn) == group_path(conn, :index)
       refute Repo.get(Group, group.id)
     end
 
     test "does not delete a group not owned by logged in user", %{conn: conn} do
-      #TODO
+      group = Repo.insert! %Group{}
+      conn = delete conn, group_path(conn, :delete, group)
+      assert redirected_to(conn) == group_path(conn, :index)
+      assert Repo.get(Group, group.id)
+    end
+
+  end
+  describe "as admin" do
+    setup do
+      user = insert(:user_admin)
+      conn = build_conn
+        |> log_in(user)
+      {:ok, [conn: conn, logged_in_user: user]}
+    end
+
+    test "admin may edit a group not owned by admin", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, owner: user)
+      conn = get conn, group_path(conn, :edit, group)
+      assert html_response(conn, 200) =~ "Edit group"
+    end
+
+    test "admin may update a group not owned by admin", %{conn: conn} do
+      group = insert(:group)
+      conn = put conn, group_path(conn, :update, group), group: @valid_attrs
+      assert redirected_to(conn) == group_path(conn, :show, group)
+      assert Repo.get_by(Group, @valid_attrs)
     end
 
     test "admin may delete a group not owned by admin", %{conn: conn} do
-      #TODO
+      group = Repo.insert! %Group{}
+      conn = delete conn, group_path(conn, :delete, group)
+      assert redirected_to(conn) == group_path(conn, :index)
+      refute Repo.get(Group, group.id)
     end
   end
 end

--- a/test/controllers/group_controller_test.exs
+++ b/test/controllers/group_controller_test.exs
@@ -37,6 +37,14 @@ defmodule Pairmotron.GroupControllerTest do
       assert Repo.get_by(Group, attrs)
     end
 
+    test "created group's owner is in the group's users", %{conn: conn, logged_in_user: user} do
+      attrs = Map.merge(@valid_attrs, %{owner_id: Integer.to_string(user.id)})
+      post conn, group_path(conn, :create), group: attrs
+      group = Repo.get_by(Group, attrs) |> Repo.preload(:users)
+      assert [only_user | [] ] = group.users
+      assert only_user.id == user.id
+    end
+
     test "does not create resource and renders errors when data is invalid", %{conn: conn} do
       conn = post conn, group_path(conn, :create), group: @invalid_attrs
       assert html_response(conn, 200) =~ "New group"

--- a/test/controllers/group_controller_test.exs
+++ b/test/controllers/group_controller_test.exs
@@ -41,7 +41,7 @@ defmodule Pairmotron.GroupControllerTest do
       attrs = Map.merge(@valid_attrs, %{owner_id: Integer.to_string(user.id)})
       post conn, group_path(conn, :create), group: attrs
       group = Repo.get_by(Group, attrs) |> Repo.preload(:users)
-      assert [only_user | [] ] = group.users
+      assert [only_user] = group.users
       assert only_user.id == user.id
     end
 

--- a/test/controllers/group_controller_test.exs
+++ b/test/controllers/group_controller_test.exs
@@ -1,0 +1,110 @@
+defmodule Pairmotron.GroupControllerTest do
+  use Pairmotron.ConnCase
+
+  alias Pairmotron.Group
+  import Pairmotron.TestHelper, only: [log_in: 2]
+
+  @valid_attrs %{name: "some content"}
+  @invalid_attrs %{}
+
+  test "redirects to sign-in when not logged in", %{conn: conn} do
+    conn = get conn, group_path(conn, :index)
+    assert redirected_to(conn) == session_path(conn, :new)
+  end
+
+  describe "while authenticated" do
+    setup do
+      user = insert(:user)
+      conn = build_conn
+        |> log_in(user)
+      {:ok, [conn: conn, logged_in_user: user]}
+    end
+
+    test "lists all entries on index", %{conn: conn} do
+      conn = get conn, group_path(conn, :index)
+      assert html_response(conn, 200) =~ "Listing groups"
+    end
+
+    test "renders form for new resources", %{conn: conn} do
+      conn = get conn, group_path(conn, :new)
+      assert html_response(conn, 200) =~ "New group"
+    end
+
+    test "creates resource and redirects when data is valid", %{conn: conn} do
+      conn = post conn, group_path(conn, :create), group: @valid_attrs
+      assert redirected_to(conn) == group_path(conn, :index)
+      assert Repo.get_by(Group, @valid_attrs)
+    end
+
+    test "created resource's owner is the currently logged in user", %{conn: conn} do
+      #TODO
+    end
+
+    test "does not create resource and renders errors when data is invalid", %{conn: conn} do
+      conn = post conn, group_path(conn, :create), group: @invalid_attrs
+      assert html_response(conn, 200) =~ "New group"
+    end
+
+    test "shows chosen resource", %{conn: conn} do
+      group = Repo.insert! %Group{}
+      conn = get conn, group_path(conn, :show, group)
+      assert html_response(conn, 200) =~ "Show group"
+    end
+
+    test "renders page not found when id is nonexistent", %{conn: conn} do
+      assert_error_sent 404, fn ->
+        get conn, group_path(conn, :show, -1)
+      end
+    end
+
+    test "renders form for editing chosen resource", %{conn: conn} do
+      group = Repo.insert! %Group{}
+      conn = get conn, group_path(conn, :edit, group)
+      assert html_response(conn, 200) =~ "Edit group"
+    end
+
+    test "does not allow editing a group not owned by logged in user", %{conn: conn} do
+      #TODO
+    end
+
+    test "admin may edit a group not owned by admin", %{conn: conn} do
+      #TODO
+    end
+
+    test "updates chosen resource and redirects when data is valid", %{conn: conn} do
+      group = Repo.insert! %Group{}
+      conn = put conn, group_path(conn, :update, group), group: @valid_attrs
+      assert redirected_to(conn) == group_path(conn, :show, group)
+      assert Repo.get_by(Group, @valid_attrs)
+    end
+
+    test "does not allow updating a group not owned by logged in user", %{conn: conn} do
+      #TODO
+    end
+
+    test "admin may update a group not owned by admin", %{conn: conn} do
+      #TODO
+    end
+
+    test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
+      group = Repo.insert! %Group{}
+      conn = put conn, group_path(conn, :update, group), group: @invalid_attrs
+      assert html_response(conn, 200) =~ "Edit group"
+    end
+
+    test "deletes chosen resource", %{conn: conn} do
+      group = Repo.insert! %Group{}
+      conn = delete conn, group_path(conn, :delete, group)
+      assert redirected_to(conn) == group_path(conn, :index)
+      refute Repo.get(Group, group.id)
+    end
+
+    test "does not delete a group not owned by logged in user", %{conn: conn} do
+      #TODO
+    end
+
+    test "admin may delete a group not owned by admin", %{conn: conn} do
+      #TODO
+    end
+  end
+end

--- a/test/controllers/group_controller_test.exs
+++ b/test/controllers/group_controller_test.exs
@@ -51,7 +51,7 @@ defmodule Pairmotron.GroupControllerTest do
     end
 
     test "shows chosen resource", %{conn: conn} do
-      group = Repo.insert! %Group{}
+      group = insert(:group)
       conn = get conn, group_path(conn, :show, group)
       assert html_response(conn, 200) =~ "Show group"
     end

--- a/test/models/group_test.exs
+++ b/test/models/group_test.exs
@@ -3,7 +3,7 @@ defmodule Pairmotron.GroupTest do
 
   alias Pairmotron.Group
 
-  @valid_attrs %{name: "some content"}
+  @valid_attrs %{name: "some content", owner_id: 1}
   @invalid_attrs %{}
 
   test "changeset with valid attributes" do

--- a/test/models/group_test.exs
+++ b/test/models/group_test.exs
@@ -1,0 +1,18 @@
+defmodule Pairmotron.GroupTest do
+  use Pairmotron.ModelCase
+
+  alias Pairmotron.Group
+
+  @valid_attrs %{name: "some content"}
+  @invalid_attrs %{}
+
+  test "changeset with valid attributes" do
+    changeset = Group.changeset(%Group{}, @valid_attrs)
+    assert changeset.valid?
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = Group.changeset(%Group{}, @invalid_attrs)
+    refute changeset.valid?
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -2,7 +2,7 @@ defmodule Pairmotron.Factory do
   # with Ecto
   use ExMachina.Ecto, repo: Pairmotron.Repo
 
-  alias Pairmotron.{Project, User}
+  alias Pairmotron.{Group, Project, User}
 
   def user_factory do
     %User{
@@ -42,4 +42,10 @@ defmodule Pairmotron.Factory do
     }
   end
 
+  def group_factory do
+    %Group{
+      name: sequence(:name, &"name #{&1}"),
+      owner: build(:user)
+    }
+  end
 end

--- a/web/controllers/controller_helpers.ex
+++ b/web/controllers/controller_helpers.ex
@@ -31,7 +31,7 @@ defmodule Pairmotron.ControllerHelpers do
   this looks for the field specified and returns it as an integer
   if possible. If not possible, it returns 0. This is intended
   to be used on association IDs so that they can easily be retrieved
-  from Ecto if necessary.
+  from Ecto if necessary. The field argument should be a binary.
   """
   def parameter_as_integer(params, field) do
     case Map.get(params, field, 0) do

--- a/web/controllers/group_controller.ex
+++ b/web/controllers/group_controller.ex
@@ -33,7 +33,7 @@ defmodule Pairmotron.GroupController do
   end
 
   def show(conn, %{"id" => id}) do
-    group = Repo.get!(Group, id)
+    group = Repo.get!(Group, id) |> Repo.preload(:owner)
     render(conn, "show.html", group: group)
   end
 

--- a/web/controllers/group_controller.ex
+++ b/web/controllers/group_controller.ex
@@ -17,7 +17,10 @@ defmodule Pairmotron.GroupController do
   end
 
   def create(conn, %{"group" => group_params}) do
-    changeset = Group.changeset(%Group{}, group_params)
+    owner_id = parameter_as_integer(group_params, "owner_id")
+    owner = Repo.get(Pairmotron.User, owner_id)
+
+    changeset = Group.changeset_for_create(%Group{}, group_params, [owner])
 
     case Repo.insert(changeset) do
       {:ok, _group} ->

--- a/web/controllers/group_controller.ex
+++ b/web/controllers/group_controller.ex
@@ -1,0 +1,65 @@
+defmodule Pairmotron.GroupController do
+  use Pairmotron.Web, :controller
+
+  alias Pairmotron.Group
+
+  def index(conn, _params) do
+    groups = Repo.all(Group)
+    render(conn, "index.html", groups: groups)
+  end
+
+  def new(conn, _params) do
+    changeset = Group.changeset(%Group{})
+    render(conn, "new.html", changeset: changeset)
+  end
+
+  def create(conn, %{"group" => group_params}) do
+    changeset = Group.changeset(%Group{}, group_params)
+
+    case Repo.insert(changeset) do
+      {:ok, _group} ->
+        conn
+        |> put_flash(:info, "Group created successfully.")
+        |> redirect(to: group_path(conn, :index))
+      {:error, changeset} ->
+        render(conn, "new.html", changeset: changeset)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    group = Repo.get!(Group, id)
+    render(conn, "show.html", group: group)
+  end
+
+  def edit(conn, %{"id" => id}) do
+    group = Repo.get!(Group, id)
+    changeset = Group.changeset(group)
+    render(conn, "edit.html", group: group, changeset: changeset)
+  end
+
+  def update(conn, %{"id" => id, "group" => group_params}) do
+    group = Repo.get!(Group, id)
+    changeset = Group.changeset(group, group_params)
+
+    case Repo.update(changeset) do
+      {:ok, group} ->
+        conn
+        |> put_flash(:info, "Group updated successfully.")
+        |> redirect(to: group_path(conn, :show, group))
+      {:error, changeset} ->
+        render(conn, "edit.html", group: group, changeset: changeset)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    group = Repo.get!(Group, id)
+
+    # Here we use delete! (with a bang) because we expect
+    # it to always work (and if it does not, it will raise).
+    Repo.delete!(group)
+
+    conn
+    |> put_flash(:info, "Group deleted successfully.")
+    |> redirect(to: group_path(conn, :index))
+  end
+end

--- a/web/controllers/group_controller.ex
+++ b/web/controllers/group_controller.ex
@@ -2,6 +2,9 @@ defmodule Pairmotron.GroupController do
   use Pairmotron.Web, :controller
 
   alias Pairmotron.Group
+  import Pairmotron.ControllerHelpers
+
+  plug :load_and_authorize_resource, model: Group, only: [:edit, :update, :delete]
 
   def index(conn, _params) do
     groups = Repo.all(Group)
@@ -31,35 +34,43 @@ defmodule Pairmotron.GroupController do
     render(conn, "show.html", group: group)
   end
 
-  def edit(conn, %{"id" => id}) do
-    group = Repo.get!(Group, id)
-    changeset = Group.changeset(group)
-    render(conn, "edit.html", group: group, changeset: changeset)
-  end
-
-  def update(conn, %{"id" => id, "group" => group_params}) do
-    group = Repo.get!(Group, id)
-    changeset = Group.changeset(group, group_params)
-
-    case Repo.update(changeset) do
-      {:ok, group} ->
-        conn
-        |> put_flash(:info, "Group updated successfully.")
-        |> redirect(to: group_path(conn, :show, group))
-      {:error, changeset} ->
-        render(conn, "edit.html", group: group, changeset: changeset)
+  def edit(conn, %{"id" => _id}) do
+    if conn.assigns.authorized do
+      group = conn.assigns.group
+      changeset = Group.changeset(group)
+      render(conn, "edit.html", group: group, changeset: changeset)
+    else
+      redirect_not_authorized(conn, group_path(conn, :index))
     end
   end
 
-  def delete(conn, %{"id" => id}) do
-    group = Repo.get!(Group, id)
+  def update(conn, %{"id" => _id, "group" => group_params}) do
+    if conn.assigns.authorized do
+      group = conn.assigns.group
+      changeset = Group.changeset(group, group_params)
 
-    # Here we use delete! (with a bang) because we expect
-    # it to always work (and if it does not, it will raise).
-    Repo.delete!(group)
+      case Repo.update(changeset) do
+        {:ok, group} ->
+          conn
+          |> put_flash(:info, "Group updated successfully.")
+          |> redirect(to: group_path(conn, :show, group))
+        {:error, changeset} ->
+          render(conn, "edit.html", group: group, changeset: changeset)
+      end
+    else
+      redirect_not_authorized(conn, group_path(conn, :index))
+    end
+  end
 
-    conn
-    |> put_flash(:info, "Group deleted successfully.")
-    |> redirect(to: group_path(conn, :index))
+  def delete(conn, %{"id" => _id}) do
+    if conn.assigns.authorized do
+      Repo.delete!(conn.assigns.group)
+
+      conn
+      |> put_flash(:info, "Group deleted successfully.")
+      |> redirect(to: group_path(conn, :index))
+    else
+      redirect_not_authorized(conn, group_path(conn, :index))
+    end
   end
 end

--- a/web/controllers/group_controller.ex
+++ b/web/controllers/group_controller.ex
@@ -12,7 +12,7 @@ defmodule Pairmotron.GroupController do
   end
 
   def new(conn, _params) do
-    changeset = Group.changeset(%Group{})
+    changeset = Group.changeset(%Group{}, %{owner_id: conn.assigns.current_user.id})
     render(conn, "new.html", changeset: changeset)
   end
 

--- a/web/models/group.ex
+++ b/web/models/group.ex
@@ -18,6 +18,7 @@ defmodule Pairmotron.Group do
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, @required_fields, @optional_fields)
+    |> foreign_key_constraint(:owner_id)
   end
 
   @doc """
@@ -27,6 +28,7 @@ defmodule Pairmotron.Group do
   def changeset_for_create(struct, params \\ %{}, users) do
     struct
     |> cast(params, @required_fields, @optional_fields)
+    |> foreign_key_constraint(:owner_id)
     |> put_assoc(:users, users)
   end
 end

--- a/web/models/group.ex
+++ b/web/models/group.ex
@@ -4,17 +4,29 @@ defmodule Pairmotron.Group do
   schema "groups" do
     field :name, :string
     belongs_to :owner, Pairmotron.User
-    many_to_many :users, Pairmotron.User, join_through: "users_groups"
+    many_to_many :users, Pairmotron.User, join_through: Pairmotron.UserGroup
 
     timestamps()
   end
+
+  @required_fields ~w(name owner_id)
+  @optional_fields ~w()
 
   @doc """
   Builds a changeset based on the `struct` and `params`.
   """
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:name, :owner_id])
-    |> validate_required([:name])
+    |> cast(params, @required_fields, @optional_fields)
+  end
+
+  @doc """
+  Builds a changeset and sets the users association. Should be used
+  when creating a group so that the owner can be set as the only user.
+  """
+  def changeset_for_create(struct, params \\ %{}, users) do
+    struct
+    |> cast(params, @required_fields, @optional_fields)
+    |> put_assoc(:users, users)
   end
 end

--- a/web/models/group.ex
+++ b/web/models/group.ex
@@ -1,0 +1,21 @@
+defmodule Pairmotron.Group do
+  use Pairmotron.Web, :model
+
+  schema "groups" do
+    field :name, :string
+    belongs_to :owner, Pairmotron.User
+    has_many :groups, Pairmotron.Group
+    many_to_many :users, Pairmotron.User, join_through: "users_groups"
+
+    timestamps()
+  end
+
+  @doc """
+  Builds a changeset based on the `struct` and `params`.
+  """
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:name])
+    |> validate_required([:name])
+  end
+end

--- a/web/models/group.ex
+++ b/web/models/group.ex
@@ -4,7 +4,6 @@ defmodule Pairmotron.Group do
   schema "groups" do
     field :name, :string
     belongs_to :owner, Pairmotron.User
-    has_many :groups, Pairmotron.Group
     many_to_many :users, Pairmotron.User, join_through: "users_groups"
 
     timestamps()
@@ -15,7 +14,7 @@ defmodule Pairmotron.Group do
   """
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:name])
+    |> cast(params, [:name, :owner_id])
     |> validate_required([:name])
   end
 end

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -12,6 +12,7 @@ defmodule Pairmotron.User do
     field :password_hash, :string
 
     has_many :pair_retros, Pairmotron.PairRetro
+    many_to_many :groups, Pairmotron.Group, join_through: "users_groups"
 
     timestamps()
   end

--- a/web/models/user_group.ex
+++ b/web/models/user_group.ex
@@ -1,0 +1,21 @@
+defmodule Pairmotron.UserGroup do
+  use Pairmotron.Web, :model
+
+  schema "users_groups" do
+    belongs_to :user, Pairmotron.User
+    belongs_to :group, Pairmotron.Group
+
+    @required_fields ~w(group_id user_id)
+    @optional_fields ~w()
+
+    timestamps()
+  end
+
+  @doc """
+  Builds a changeset based on the `struct` and `params`.
+  """
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, @required_fields, @optional_fields)
+  end
+end

--- a/web/router.ex
+++ b/web/router.ex
@@ -37,8 +37,11 @@ defmodule Pairmotron.Router do
     get "/pairs", PageController, :index
     resources "/users", UserController
     resources "/projects", ProjectController
+    resources "/groups", GroupController
+
     get "/pair_retros/new/:pair_id", PairRetroController, :new
     resources "/pair_retros", PairRetroController, except: [:new]
+
     get "/:year/:week", PageController, :show
     delete "/:year/:week", PageController, :delete
   end

--- a/web/templates/group/edit.html.eex
+++ b/web/templates/group/edit.html.eex
@@ -1,0 +1,6 @@
+<h2>Edit group</h2>
+
+<%= render "form.html", changeset: @changeset,
+                        action: group_path(@conn, :update, @group) %>
+
+<%= link "Back", to: group_path(@conn, :index) %>

--- a/web/templates/group/form.html.eex
+++ b/web/templates/group/form.html.eex
@@ -1,0 +1,17 @@
+<%= form_for @changeset, @action, fn f -> %>
+  <%= if @changeset.action do %>
+    <div class="alert alert-danger">
+      <p>Oops, something went wrong! Please check the errors below.</p>
+    </div>
+  <% end %>
+
+  <div class="form-group">
+    <%= label f, :name, class: "control-label" %>
+    <%= text_input f, :name, class: "form-control" %>
+    <%= error_tag f, :name %>
+  </div>
+
+  <div class="form-group">
+    <%= submit "Submit", class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/web/templates/group/form.html.eex
+++ b/web/templates/group/form.html.eex
@@ -5,7 +5,7 @@
     </div>
   <% end %>
 
-  <%= hidden_input f, :user_id, value: value_from_changeset(@changeset, :owner_id) %>
+  <%= hidden_input f, :owner_id, value: value_from_changeset(@changeset, :owner_id) %>
 
   <div class="form-group">
     <%= label f, :name, class: "control-label" %>

--- a/web/templates/group/form.html.eex
+++ b/web/templates/group/form.html.eex
@@ -5,6 +5,8 @@
     </div>
   <% end %>
 
+  <%= hidden_input f, :user_id, value: value_from_changeset(@changeset, :owner_id) %>
+
   <div class="form-group">
     <%= label f, :name, class: "control-label" %>
     <%= text_input f, :name, class: "form-control" %>

--- a/web/templates/group/form.html.eex
+++ b/web/templates/group/form.html.eex
@@ -6,6 +6,7 @@
   <% end %>
 
   <%= hidden_input f, :owner_id, value: value_from_changeset(@changeset, :owner_id) %>
+  <%= error_tag f, :owner_id %>
 
   <div class="form-group">
     <%= label f, :name, class: "control-label" %>

--- a/web/templates/group/index.html.eex
+++ b/web/templates/group/index.html.eex
@@ -1,0 +1,26 @@
+<h2>Listing groups</h2>
+
+<table class="table">
+  <thead>
+    <tr>
+      <th>Name</th>
+
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+<%= for group <- @groups do %>
+    <tr>
+      <td><%= group.name %></td>
+
+      <td class="text-right">
+        <%= link "Show", to: group_path(@conn, :show, group), class: "btn btn-default btn-xs" %>
+        <%= link "Edit", to: group_path(@conn, :edit, group), class: "btn btn-default btn-xs" %>
+        <%= link "Delete", to: group_path(@conn, :delete, group), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs" %>
+      </td>
+    </tr>
+<% end %>
+  </tbody>
+</table>
+
+<%= link "New group", to: group_path(@conn, :new) %>

--- a/web/templates/group/new.html.eex
+++ b/web/templates/group/new.html.eex
@@ -1,0 +1,6 @@
+<h2>New group</h2>
+
+<%= render "form.html", changeset: @changeset,
+                        action: group_path(@conn, :create) %>
+
+<%= link "Back", to: group_path(@conn, :index) %>

--- a/web/templates/group/show.html.eex
+++ b/web/templates/group/show.html.eex
@@ -7,6 +7,11 @@
     <%= @group.name %>
   </li>
 
+  <li>
+    <strong>Owner:</strong>
+    <%= @group.owner.name %>
+  </li>
+
 </ul>
 
 <%= link "Edit", to: group_path(@conn, :edit, @group) %>

--- a/web/templates/group/show.html.eex
+++ b/web/templates/group/show.html.eex
@@ -1,0 +1,13 @@
+<h2>Show group</h2>
+
+<ul>
+
+  <li>
+    <strong>Name:</strong>
+    <%= @group.name %>
+  </li>
+
+</ul>
+
+<%= link "Edit", to: group_path(@conn, :edit, @group) %>
+<%= link "Back", to: group_path(@conn, :index) %>

--- a/web/templates/layout/app.html.eex
+++ b/web/templates/layout/app.html.eex
@@ -19,6 +19,7 @@
           <ul class="nav nav-pills pull-right">
             <li><%= link "Pairs", to: page_path(@conn, :index) %></li>
             <li><%= link "Users", to: user_path(@conn, :index) %></li>
+            <li><%= link "Groups", to: group_path(@conn, :index) %></li>
             <li><%= link "Projects", to: project_path(@conn, :index) %></li>
             <li><%= link "My Retros", to: pair_retro_path(@conn, :index) %></li>
             <li>

--- a/web/views/group_view.ex
+++ b/web/views/group_view.ex
@@ -1,0 +1,3 @@
+defmodule Pairmotron.GroupView do
+  use Pairmotron.Web, :view
+end

--- a/web/views/pair_retro_view.ex
+++ b/web/views/pair_retro_view.ex
@@ -1,10 +1,6 @@
 defmodule Pairmotron.PairRetroView do
   use Pairmotron.Web, :view
 
-  def value_from_changeset(changeset, value) do
-    elem(Ecto.Changeset.fetch_field(changeset, value), 1)
-  end
-
   def format_date(nil), do: ""
   def format_date(date), do: Ecto.Date.to_string(date)
 

--- a/web/views/view_helper.ex
+++ b/web/views/view_helper.ex
@@ -8,4 +8,12 @@ defmodule Pairmotron.ViewHelpers do
   def is_admin?(user) do
     user.is_admin
   end
+
+  @doc """
+  Given a changeset and a field that whose value is needed, returns
+  that value and only that value. Useful for hidden fields in forms.
+  """
+  def value_from_changeset(changeset, field) do
+    elem(Ecto.Changeset.fetch_field(changeset, field), 1)
+  end
 end


### PR DESCRIPTION
Adds groups models/migration and some basic UI around them.

### TODO:

- [x] Add group model/migration
- [x] Add group CRUD
- [x] Add resource specific authorization to groups based on owner
- [x] Add logic to set currently logged in user as owner for new groups
- [x] Add logic to add currently logged in user to the users of a new group
- [x] Add group link to toolbar
- [x] Display the owner for the group :show action

### New issues to create after this is complete. A number of these will be recategorized.

- [x] Allow groups to be private or public. Private groups would only be visible to members that are in them.
- [x] Add UI to transfer the ownership of a group
- [ ] Add support for group-specific roles, so that the owner isn't the only user that can add users or edit groups.
- [x] Allow users to request membership in a group.
- [x] Make Projects group-specific
- [x] Add ability for users to leave a group.
- [x] Add UI to allow owners of groups to remove users from a group
- [x] Add functionality for owners of groups to invite users to the groups
  - Discuss: Should this be its own model, or could this data belong on the UserGroup joining table?
  - Add UI to allow owners to select users that should receive invites to their group.
  - Add group_invitation model
  - Add group_invitation routes/controllers
  - Add group_invitation UI
- [x] Add dropdown to select Group for "/pairs"
- ~~Add ability to filter users by group on the users index~~
  - ~~Add filter for users in no groups~~
- [x] Display the user's groups on the user show action
- [ ] Display the group's users on the group show action (or perhaps a different controller?)
- [ ] Add landing page to redirect users to that aren't yet associated with any groups


Closes #10 