### PR TITLE
Move the submit buttons to the right for regististration and login

### DIFF
--- a/web/templates/registration/new.html.eex
+++ b/web/templates/registration/new.html.eex
@@ -31,7 +31,7 @@
   </div>
 
   <div class="form-group">
-    <%= submit "Register", class: "btn btn-primary" %>
-    <%= link("Login", to: session_path(@conn, :new), class: "btn btn-success pull-right") %>
+    <%= link("Login", to: session_path(@conn, :new), class: "btn btn-success") %>
+    <%= submit "Register", class: "btn btn-primary pull-right" %>
   </div>
 <% end %>

--- a/web/templates/session/new.html.eex
+++ b/web/templates/session/new.html.eex
@@ -12,7 +12,7 @@
 </div>
 
 <div class="form-group">
-    <%= submit "Login", class: "btn btn-primary" %>
-    <%= link("Sign Up", to: registration_path(@conn, :new), class: "btn btn-success pull-right") %>
+    <%= link("Sign Up", to: registration_path(@conn, :new), class: "btn btn-success") %>
+    <%= submit "Login", class: "btn btn-primary pull-right" %>
 </div>
 <% end %>


### PR DESCRIPTION
@mbramson I was annoyed that the "submit" button for registration and login were on the left instead of the right. Now they are on the right.