### PR TITLE
Redesign navbar to be an actual navbar

### DIFF
--- a/brunch-config.js
+++ b/brunch-config.js
@@ -8,20 +8,6 @@ exports.config = {
         "js/admin_lte2.js": ["web/static/vendor/admin_lte2.js"],
         "js/jquery.min.js": ["web/static/vendor/jquery.min.js"]
       }
-      // To use a separate vendor.js bundle, specify two files path
-      // http://brunch.io/docs/config#-files-
-      // joinTo: {
-      //  "js/app.js": /^(web\/static\/js)/,
-      //  "js/vendor.js": /^(web\/static\/vendor)|(deps)/
-      // }
-      //
-      // To change the order of concatenation of files, explicitly mention here
-      // order: {
-      //   before: [
-      //     "web/static/vendor/js/jquery-2.1.1.js",
-      //     "web/static/vendor/js/bootstrap.min.js"
-      //   ]
-      // }
     },
     stylesheets: {
       joinTo: {
@@ -72,48 +58,12 @@ exports.config = {
   },
 
   npm: {
-    enabled: true
+    enabled: true,
+    whitelist: [
+      "jquery",
+      "bootstrap",
+      "bootstrap-select",
+      "phoenix",
+      "phoenix_html"],
   }
 };
-
-// To add the ExAdmin generated assets to your brunch build, do the following:
-//
-// Replace
-//
-//     javascripts: {
-//       joinTo: "js/app.js"
-//     },
-//
-// With
-//
-//     javascripts: {
-//       joinTo: {
-//         "js/app.js": /^(web\/static\/js)|(node_modules)/,
-//         "js/ex_admin_common.js": ["web/static/vendor/ex_admin_common.js"],
-//         "js/admin_lte2.js": ["web/static/vendor/admin_lte2.js"],
-//         "js/jquery.min.js": ["web/static/vendor/jquery.min.js"],
-//       }
-//     },
-//
-// Replace
-//
-//     stylesheets: {
-//       joinTo: "css/app.css",
-//       order: {
-//         after: ["web/static/css/app.css"] // concat app.css last
-//       }
-//     },
-//
-// With
-//
-//     stylesheets: {
-//       joinTo: {
-//         "css/app.css": /^(web\/static\/css)/,
-//         "css/admin_lte2.css": ["web/static/vendor/admin_lte2.css"],
-//         "css/active_admin.css.css": ["web/static/vendor/active_admin.css.css"],
-//       },
-//       order: {
-//         after: ["web/static/css/app.css"] // concat app.css last
-//       }
-//     },
-//

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "watch": "brunch watch --stdin"
   },
   "dependencies": {
+    "bootstrap": ">=3.3.7",
+    "bootstrap-select": ">=1.10.0",
+    "jquery": ">=3.0",
     "phoenix": "file:deps/phoenix",
     "phoenix_html": "file:deps/phoenix_html"
   },

--- a/web/static/css/phoenix.css
+++ b/web/static/css/phoenix.css
@@ -10,7 +10,6 @@
 
 /* Space out content a bit */
 body, form, table {
-  margin-top: 20px;
   margin-bottom: 20px;
 }
 
@@ -31,15 +30,8 @@ form.link, form.button {
 .header {
 }
 .logo {
-  width: 400px;
-  height: 71px;
-  display: inline-block;
   font-family: 'Indie Flower', cursive;
-  font-size: 60pt;
-  /* background-image: url("/images/phoenix.png"); */
-  background-size: 400px 71px;
-}
-.logo a {
+  font-size: 30pt;
   color: black;
   text-decoration: none;
 }
@@ -51,12 +43,6 @@ form.link, form.button {
   padding-left: 15px;
 }
 
-/* Customize container */
-@media (min-width: 768px) {
-  .container {
-    max-width: 730px;
-  }
-}
 .container-narrow > hr {
   margin: 30px 0;
 }

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -19,3 +19,9 @@ import "phoenix_html"
 // paths "./socket" or full ones "web/static/js/socket".
 
 // import socket from "./socket"
+import $ from "jquery"
+import "jquery"
+import "bootstrap-select"
+
+global.jQuery = require("jquery")
+global.bootstrap = require("bootstrap")

--- a/web/templates/layout/app.html.eex
+++ b/web/templates/layout/app.html.eex
@@ -13,28 +13,35 @@
   </head>
 
   <body>
-    <div class="container">
-      <header class="header">
-        <nav role="navigation">
-          <ul class="nav nav-pills pull-right">
+    <nav role="navigation" class="navbar navbar-default navbar-static-top">
+      <div class="container">
+        <div class="navbar-header">
+          <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-collapse-1" aria-expanded="false">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+          <%= link "Pairmotron", to: page_path(@conn, :index), class: "logo navbar-brand" %>
+        </div>
+        <div class="collapse navbar-collapse" id="navbar-collapse-1">
+          <ul class="nav navbar-nav navbar-right">
             <li><%= link "Pairs", to: page_path(@conn, :index) %></li>
             <li><%= link "Groups", to: group_path(@conn, :index) %></li>
             <li><%= link "Projects", to: project_path(@conn, :index) %></li>
             <li><%= link "My Retros", to: pair_retro_path(@conn, :index) %></li>
             <li><%= link "Profile", to: profile_path(@conn, :show) %></li>
-            <li>
               <%= case @conn.assigns[:current_user] do %>
                 <% nil -> %>
-                  <%= link "Login", class: "btn btn-success", role: "button", to: session_path(@conn, :new) %>
-                <% _current_user -> %>
-                  <%= link "Logout", class: "btn btn-danger", role: "button", to: session_path(@conn, :delete) %>
-              <% end %>         
-            </li>
+                  <%= link "Login", class: "btn btn-success navbar-btn", role: "button", to: session_path(@conn, :new) %>
+                <% current_user -> %>
+                  <li><%= link "Logout", to: session_path(@conn, :delete) %></li>
+              <% end %>
           </ul>
-        </nav>
-        <span class="logo"><%= link "Pairmotron", to: page_path(@conn, :index) %>
-</span>
-      </header>
+        </div>
+      </div>
+    </nav>
+    <div class="container">
 
       <p class="alert alert-info" role="alert"><%= get_flash(@conn, :info) %></p>
       <p class="alert alert-danger" role="alert"><%= get_flash(@conn, :error) %></p>


### PR DESCRIPTION
Make the navbar a real static navbar
Include the collapse.js functionality (and more) from bootstrap
Fix some css mostly around logo and different margins

New design:
<img width="1190" alt="screen shot 2017-01-29 at 3 10 04 pm" src="https://cloud.githubusercontent.com/assets/4420576/22407506/a562dac8-e635-11e6-89f5-841d56a5feee.png">

Mobile browsers now work with a collapse:
<img width="374" alt="screen shot 2017-01-29 at 3 10 24 pm" src="https://cloud.githubusercontent.com/assets/4420576/22407509/b0a2c3f8-e635-11e6-9408-80b5b730e4ad.png">


Closes #48 

@mbramson Eventually I think the Logout link and the Profile link can go into a dropdown (with the dropdown text being the user's name), but we have a bunch of tests that test for inclusion of a user's name on the page. We'll have to improve those tests and probably decide that more than 2 things go into the dropdown before we make that change.