### PR TITLE
Adjust pairs route

### DIFF
--- a/test/controllers/group_controller_test.exs
+++ b/test/controllers/group_controller_test.exs
@@ -15,8 +15,7 @@ defmodule Pairmotron.GroupControllerTest do
   describe "while authenticated" do
     setup do
       user = insert(:user)
-      conn = build_conn
-        |> log_in(user)
+      conn = build_conn() |> log_in(user)
       {:ok, [conn: conn, logged_in_user: user]}
     end
 
@@ -112,8 +111,7 @@ defmodule Pairmotron.GroupControllerTest do
   describe "as admin" do
     setup do
       user = insert(:user_admin)
-      conn = build_conn
-        |> log_in(user)
+      conn = build_conn() |> log_in(user)
       {:ok, [conn: conn, logged_in_user: user]}
     end
 

--- a/test/controllers/pair_controller_test.exs
+++ b/test/controllers/pair_controller_test.exs
@@ -13,8 +13,7 @@ defmodule Pairmotron.PairControllerTest do
   describe "while authenticated" do
     setup do
       user = insert(:user)
-      conn = build_conn
-        |> log_in(user)
+      conn = build_conn() |> log_in(user)
       {:ok, [conn: conn, logged_in_user: user]}
     end
 

--- a/test/controllers/pair_retro_controller_test.exs
+++ b/test/controllers/pair_retro_controller_test.exs
@@ -23,8 +23,7 @@ defmodule Pairmotron.PairRetroControllerTest do
   describe "while authenticated" do
     setup do
       user = insert(:user)
-      conn = build_conn
-        |> log_in(user)
+      conn = build_conn() |> log_in(user)
       {:ok, [conn: conn, logged_in_user: user]}
     end
 
@@ -40,7 +39,7 @@ defmodule Pairmotron.PairRetroControllerTest do
     end
 
     test "does not list a retrospective of a different user", %{conn: conn} do
-      {_other_user, _pair, retro} = create_user_and_pair_and_retro
+      {_other_user, _pair, retro} = create_user_and_pair_and_retro()
       conn = get conn, pair_retro_path(conn, :index)
       refute html_response(conn, 200) =~ Ecto.Date.to_string(retro.pair_date)
     end
@@ -182,8 +181,7 @@ defmodule Pairmotron.PairRetroControllerTest do
   describe "as admin" do
     setup do
       user = insert(:user_admin)
-      conn = build_conn
-        |> log_in(user)
+      conn = build_conn() |> log_in(user)
       {:ok, [conn: conn, logged_in_user: user]}
     end
 

--- a/test/controllers/profile_controller_test.exs
+++ b/test/controllers/profile_controller_test.exs
@@ -14,7 +14,7 @@ defmodule Pairmotron.ProfileControllerTest do
   describe "while authenticated" do
     setup do
       user = insert(:user)
-      conn = build_conn |> log_in(user)
+      conn = build_conn() |> log_in(user)
       {:ok, [conn: conn, logged_in_user: user]}
     end
 

--- a/test/controllers/project_controller_test.exs
+++ b/test/controllers/project_controller_test.exs
@@ -15,8 +15,7 @@ defmodule Pairmotron.ProjectControllerTest do
   describe "while authenticated" do
     setup do
       user = insert(:user)
-      conn = build_conn
-        |> log_in(user)
+      conn = build_conn() |> log_in(user)
       {:ok, [conn: conn, logged_in_user: user]}
     end
 

--- a/test/lib/plug/require_admin_test.exs
+++ b/test/lib/plug/require_admin_test.exs
@@ -6,8 +6,7 @@ defmodule Pairmotron.Plug.RequireAdminTest do
   describe "while authenticated" do
     setup do
       user = insert(:user)
-      conn = build_conn
-        |> log_in(user)
+      conn = build_conn() |> log_in(user)
       {:ok, [conn: conn, logged_in_user: user]}
     end
     test "redirects when user is not an admin ", %{conn: conn, logged_in_user: user} do
@@ -19,8 +18,7 @@ defmodule Pairmotron.Plug.RequireAdminTest do
   describe "as admin" do
     setup do
       user = insert(:user_admin)
-      conn = build_conn
-        |> log_in(user)
+      conn = build_conn() |> log_in(user)
       {:ok, [conn: conn, logged_in_user: user]}
     end
     test "passes through when user is an admin", %{conn: conn, logged_in_user: user} do

--- a/test/views/pair_retro_view_test.exs
+++ b/test/views/pair_retro_view_test.exs
@@ -3,12 +3,12 @@ defmodule Pairmotron.PairRetroViewTest do
   alias Pairmotron.PairRetroView
 
   test "returns an empty array when there is no projects field in the conn assign" do
-    conn = build_conn
+    conn = build_conn()
     assert PairRetroView.projects_for_select(conn) == []
   end
 
   test "returns an array of projects when there are projects in the conn assign" do
-    conn = build_conn
+    conn = build_conn()
     project = insert(:project)
     conn = Plug.Conn.assign(conn, :projects, [project])
     expected_projects = ["#{project.name}": project.id]

--- a/test/views/pair_view_test.exs
+++ b/test/views/pair_view_test.exs
@@ -8,21 +8,21 @@ defmodule Pairmotron.PairViewTest do
       logged_in_user = insert(:user)
       other_user = insert(:user)
       pair = create_pair([other_user]) |> Pairmotron.Repo.preload([:users])
-      conn = build_conn |> log_in(logged_in_user)
+      conn = build_conn() |> log_in(logged_in_user)
       refute PairView.current_user_in_pair(conn, pair)
     end
 
     test "is true when the logged in user is in the pair" do
       user = insert(:user)
       pair = create_pair([user]) |> Pairmotron.Repo.preload([:users])
-      conn = build_conn |> log_in(user)
+      conn = build_conn() |> log_in(user)
       assert PairView.current_user_in_pair(conn, pair)
     end
 
     test "is false when no user is logged in" do
       user = insert(:user)
       pair = create_pair([user])
-      conn = build_conn
+      conn = build_conn()
       refute PairView.current_user_in_pair(conn, pair)
     end
   end

--- a/web/router.ex
+++ b/web/router.ex
@@ -55,8 +55,8 @@ defmodule Pairmotron.Router do
     get "/pair_retros/new/:pair_id", PairRetroController, :new
     resources "/pair_retros", PairRetroController, except: [:new]
 
-    get "/:year/:week", PairController, :show
-    delete "/:year/:week", PairController, :delete
+    get "/pairs/:year/:week", PairController, :show
+    delete "/pairs/:year/:week", PairController, :delete
   end
 
 end

--- a/web/router.ex
+++ b/web/router.ex
@@ -39,7 +39,7 @@ defmodule Pairmotron.Router do
 
   scope "/admin", ExAdmin do
     pipe_through [:browser, :authenticate, :admin]
-    admin_routes
+    admin_routes()
   end
 
   scope "/", Pairmotron do


### PR DESCRIPTION
Currently the pairs route for a specific week is /year/week. This is a bit unintuitive since currently, the current week's pairs are at /pairs. I adjusted the specific week route so that it was /pairs/year/week.

I also fixed a number of elixir 1.4 warnings around functions without () that are ambiguous.