### PR TITLE
Add :show action to allowable actions for user_groups admin

### DIFF
--- a/web/admin/user_group.ex
+++ b/web/admin/user_group.ex
@@ -3,6 +3,6 @@ defmodule Pairmotron.ExAdmin.UserGroup do
 
   register_resource Pairmotron.UserGroup do
     filter [:user, :group]
-    action_items only: [:new, :delete]
+    action_items only: [:new, :delete, :show]
   end
 end


### PR DESCRIPTION
The result of the :new action is a redirect to the :show action, which shows a 403 route if :show is not allowed.

@mbramson This is the fix for the bug you found.