### PR TITLE
73: Make projects group specific

### DIFF
--- a/lib/abilities.ex
+++ b/lib/abilities.ex
@@ -9,26 +9,25 @@ defimpl Canada.Can, for: Pairmotron.User do
   def can?(%User{id: user_id}, action, %Group{owner_id: user_id})
     when action in [:edit, :update, :delete], do: true
 
-  def can?(%User{id: user_id}, :show, project = %Project{}) do
-    if is_nil(project.group_id) do
-      project = project |> Pairmotron.Repo.preload([{:pair_retros, :user}])
-      project.pair_retros
-      |> Enum.any?(fn retro -> retro.user.id == user_id end)
-    else
-      project = project |> Pairmotron.Repo.preload([{:group, :users}])
-      project.group.users
-      |> Enum.any?(fn user -> user.id == user_id end)
-    end
+  def can?(%User{id: user_id}, :show, project = %Project{group_id: nil}) do
+    project = project |> Pairmotron.Repo.preload([{:pair_retros, :user}])
+    project.pair_retros
+    |> Enum.any?(fn retro -> retro.user.id == user_id end)
   end
+
+  def can?(%User{id: user_id}, :show, project = %Project{}) do
+    project = project |> Pairmotron.Repo.preload([{:group, :users}])
+    project.group.users
+    |> Enum.any?(fn user -> user.id == user_id end)
+  end
+
+  def can?(%User{}, action, %Project{group_id: nil})
+    when action in [:edit, :update, :delete], do: false
 
   def can?(%User{id: user_id}, action, project = %Project{})
     when action in [:edit, :update, :delete] do
-    if is_nil(project.group_id) do
-      false
-    else
-      project = project |> Pairmotron.Repo.preload(:group)
-      project.group.owner_id == user_id
-    end
+    project = project |> Pairmotron.Repo.preload(:group)
+    project.group.owner_id == user_id
   end
 
   def can?(%User{}, _, _), do: false

--- a/lib/abilities.ex
+++ b/lib/abilities.ex
@@ -11,7 +11,9 @@ defimpl Canada.Can, for: Pairmotron.User do
 
   def can?(%User{id: user_id}, :show, project = %Project{}) do
     if is_nil(project.group_id) do
-      false
+      project = project |> Pairmotron.Repo.preload([{:pair_retros, :user}])
+      project.pair_retros
+      |> Enum.any?(fn retro -> retro.user.id == user_id end)
     else
       project = project |> Pairmotron.Repo.preload([{:group, :users}])
       project.group.users

--- a/lib/abilities.ex
+++ b/lib/abilities.ex
@@ -9,6 +9,16 @@ defimpl Canada.Can, for: Pairmotron.User do
   def can?(%User{id: user_id}, action, %Group{owner_id: user_id})
     when action in [:edit, :update, :delete], do: true
 
+  def can?(%User{id: user_id}, :show, project = %Project{}) do
+    if is_nil(project.group_id) do
+      false
+    else
+      project = project |> Pairmotron.Repo.preload([{:group, :users}])
+      project.group.users
+      |> Enum.any?(fn user -> user.id == user_id end)
+    end
+  end
+
   def can?(%User{id: user_id}, action, project = %Project{})
     when action in [:edit, :update, :delete] do
     if is_nil(project.group_id) do

--- a/lib/abilities.ex
+++ b/lib/abilities.ex
@@ -1,5 +1,5 @@
 defimpl Canada.Can, for: Pairmotron.User do
-  alias Pairmotron.{Group, PairRetro, User}
+  alias Pairmotron.{Group, PairRetro, Project, User}
 
   def can?(%User{is_admin: true}, _, _), do: true
 
@@ -8,6 +8,16 @@ defimpl Canada.Can, for: Pairmotron.User do
 
   def can?(%User{id: user_id}, action, %Group{owner_id: user_id})
     when action in [:edit, :update, :delete], do: true
+
+  def can?(%User{id: user_id}, action, project = %Project{})
+    when action in [:edit, :update, :delete] do
+    if is_nil(project.group_id) do
+      false
+    else
+      project = project |> Pairmotron.Repo.preload(:group)
+      project.group.owner_id == user_id
+    end
+  end
 
   def can?(%User{}, _, _), do: false
 end

--- a/priv/repo/migrations/20170201015913_add_group_to_project.exs
+++ b/priv/repo/migrations/20170201015913_add_group_to_project.exs
@@ -1,0 +1,11 @@
+defmodule Pairmotron.Repo.Migrations.AddGroupToProject do
+  use Ecto.Migration
+
+  def change do
+
+    alter table(:projects) do
+      add :group_id, references(:groups, on_delete: :delete_all)
+    end
+
+  end
+end

--- a/priv/repo/migrations/20170201015913_add_group_to_project.exs
+++ b/priv/repo/migrations/20170201015913_add_group_to_project.exs
@@ -4,7 +4,7 @@ defmodule Pairmotron.Repo.Migrations.AddGroupToProject do
   def change do
 
     alter table(:projects) do
-      add :group_id, references(:groups, on_delete: :delete_all)
+      add :group_id, references(:groups, on_delete: :nilify_all)
     end
 
   end

--- a/test/controllers/project_controller_test.exs
+++ b/test/controllers/project_controller_test.exs
@@ -93,8 +93,27 @@ defmodule Pairmotron.ProjectControllerTest do
       assert html_response(conn, 200) =~ "Show project"
     end
 
+    test "shows project if user has created a retro associated with project and project not associated with group",
+      %{conn: conn, logged_in_user: user} do
+      project = insert(:project)                  # project not associated with any group
+      pair = create_pair([user])                  # pair the user is in
+      create_retro(user, pair, project)           # that has a retrospective using that project
+      conn = get conn, project_path(conn, :show, project)
+      assert html_response(conn, 200) =~ "Show project"
+    end
+
     test "does not show project if user not in associated group", %{conn: conn} do
       project = insert(:project)
+      conn = get conn, project_path(conn, :show, project)
+      assert redirected_to(conn) == project_path(conn, :index)
+    end
+
+    test "does not show project if user has created a project retro and project is associated with group user is not in",
+      %{conn: conn, logged_in_user: user} do
+      group = insert(:group)                      # group user is not in
+      project = insert(:project, %{group: group}) # project associated with that group
+      pair = create_pair([user])                  # pair the user is in
+      create_retro(user, pair, project)           # that has a retrospective using that project
       conn = get conn, project_path(conn, :show, project)
       assert redirected_to(conn) == project_path(conn, :index)
     end

--- a/test/controllers/project_controller_test.exs
+++ b/test/controllers/project_controller_test.exs
@@ -116,6 +116,15 @@ defmodule Pairmotron.ProjectControllerTest do
       assert Repo.get_by(Project, @valid_attrs)
     end
 
+    test "cannot update project to have new group", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{owner: user, users: [user]})
+      project = insert(:project, %{group: group})
+      other_group = insert(:group, %{owner: user, users: [user]})
+      put conn, project_path(conn, :update, project), project: %{group_id: other_group.id}
+      updated_project = Repo.get(Project, project.id)
+      assert updated_project.group_id == group.id
+    end
+
     test "does not update project if user is in associated group but not owner", %{conn: conn, logged_in_user: user} do
       group = insert(:group, %{users: [user]})
       project = insert(:project, %{group: group})

--- a/test/controllers/project_controller_test.exs
+++ b/test/controllers/project_controller_test.exs
@@ -86,16 +86,22 @@ defmodule Pairmotron.ProjectControllerTest do
       assert html_response(conn, 200) =~ "New project"
     end
 
-    test "shows chosen resource", %{conn: conn} do
-      project = Repo.insert! %Project{}
+    test "shows project if user is in associated group", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{users: [user]}) # user is not owner
+      project = insert(:project, %{group: group})
       conn = get conn, project_path(conn, :show, project)
       assert html_response(conn, 200) =~ "Show project"
     end
 
+    test "does not show project if user not in associated group", %{conn: conn} do
+      project = insert(:project)
+      conn = get conn, project_path(conn, :show, project)
+      assert redirected_to(conn) == project_path(conn, :index)
+    end
+
     test "renders page not found when id is nonexistent", %{conn: conn} do
-      assert_error_sent 404, fn ->
-        get conn, project_path(conn, :show, -1)
-      end
+      conn = get conn, project_path(conn, :show, -1)
+      assert html_response(conn, 404) =~ "Page not found"
     end
 
     test "allows edit of project if user is owner of associated group", %{conn: conn, logged_in_user: user} do

--- a/test/controllers/project_controller_test.exs
+++ b/test/controllers/project_controller_test.exs
@@ -31,12 +31,6 @@ defmodule Pairmotron.ProjectControllerTest do
       assert html_response(conn, 200) =~ group.name
     end
 
-    test "links to edit of project if project has no group", %{conn: conn} do
-      project = insert(:project)
-      conn = get conn, project_path(conn, :index)
-      assert html_response(conn, 200) =~ project_path(conn, :edit, project)
-    end
-
     test "links to edit of project if user is owner project's group", %{conn: conn, logged_in_user: user} do
       group = insert(:group, %{owner: user, users: [user]})
       project = insert(:project, %{group: group})

--- a/test/controllers/project_controller_test.exs
+++ b/test/controllers/project_controller_test.exs
@@ -53,7 +53,14 @@ defmodule Pairmotron.ProjectControllerTest do
       refute html_response(conn, 200) =~ project.name
     end
 
-    test "renders form for new resources", %{conn: conn} do
+    test "renders links to create and edit group if user is not in a group", %{conn: conn} do
+      conn = get conn, project_path(conn, :new)
+      assert html_response(conn, 200) =~ group_path(conn, :new)
+      assert html_response(conn, 200) =~ group_path(conn, :index)
+    end
+
+    test "renders form for new resource if user is in any group", %{conn: conn, logged_in_user: user} do
+      insert(:group, %{owner: user, users: [user]})
       conn = get conn, project_path(conn, :new)
       assert html_response(conn, 200) =~ "New project"
     end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -38,7 +38,7 @@ defmodule Pairmotron.Factory do
     %Project{
       name: sequence(:name, &"project #{&1}"),
       description: sequence(:description, &"description #{&1}"),
-      url: sequence(:url, &"http://example-#{&1}.com")
+      url: sequence(:url, &"http://example-#{&1}.com"),
     }
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -38,7 +38,7 @@ defmodule Pairmotron.Factory do
     %Project{
       name: sequence(:name, &"project #{&1}"),
       description: sequence(:description, &"description #{&1}"),
-      url: sequence(:url, &"http://example-#{&1}.com"),
+      url: sequence(:url, &"http://example-#{&1}.com")
     }
   end
 

--- a/web/controllers/pair_retro_controller.ex
+++ b/web/controllers/pair_retro_controller.ex
@@ -39,8 +39,8 @@ defmodule Pairmotron.PairRetroController do
   end
 
   def show(conn = @authorized_conn, _params) do
-      pair_retro = Repo.preload(conn.assigns.pair_retro, :project)
-      render(conn, "show.html", pair_retro: pair_retro)
+    pair_retro = Repo.preload(conn.assigns.pair_retro, :project)
+    render(conn, "show.html", pair_retro: pair_retro)
   end
   def show(conn, _params) do
     redirect_not_authorized(conn, pair_retro_path(conn, :index))

--- a/web/controllers/project_controller.ex
+++ b/web/controllers/project_controller.ex
@@ -17,12 +17,12 @@ defmodule Pairmotron.ProjectController do
     groups = Group.groups_for_user(conn.assigns.current_user)
              |> Repo.all
     conn = assign(conn, :groups, groups)
-    changeset = Project.changeset(%Project{})
+    changeset = Project.changeset_for_create(%Project{})
     render(conn, "new.html", changeset: changeset)
   end
 
   def create(conn, %{"project" => project_params}) do
-    changeset = Project.changeset(%Project{}, project_params)
+    changeset = Project.changeset_for_create(%Project{}, project_params)
 
     case Repo.insert(changeset) do
       {:ok, _project} ->

--- a/web/controllers/project_controller.ex
+++ b/web/controllers/project_controller.ex
@@ -16,9 +16,14 @@ defmodule Pairmotron.ProjectController do
   def new(conn, _params) do
     groups = Group.groups_for_user(conn.assigns.current_user)
              |> Repo.all
-    conn = assign(conn, :groups, groups)
-    changeset = Project.changeset_for_create(%Project{}, %{}, groups)
-    render(conn, "new.html", changeset: changeset)
+    case groups do
+      [] ->
+        render(conn, "no_groups.html")
+      groups ->
+        conn = assign(conn, :groups, groups)
+        changeset = Project.changeset_for_create(%Project{}, %{}, groups)
+        render(conn, "new.html", changeset: changeset)
+    end
   end
 
   def create(conn, %{"project" => project_params}) do

--- a/web/controllers/project_controller.ex
+++ b/web/controllers/project_controller.ex
@@ -53,7 +53,7 @@ defmodule Pairmotron.ProjectController do
 
   def update(conn = @authorized_conn, %{"project" => project_params}) do
     project = conn.assigns.project
-    changeset = Project.changeset(project, project_params)
+    changeset = Project.changeset_for_update(project, project_params)
 
     case Repo.update(changeset) do
       {:ok, project} ->

--- a/web/controllers/project_controller.ex
+++ b/web/controllers/project_controller.ex
@@ -4,7 +4,7 @@ defmodule Pairmotron.ProjectController do
   alias Pairmotron.{Group, Project}
   import Pairmotron.ControllerHelpers
 
-  plug :load_and_authorize_resource, model: Project, only: [:edit, :update, :delete]
+  plug :load_and_authorize_resource, model: Project, only: [:show, :edit, :update, :delete]
 
   def index(conn, _params) do
     projects = Project.projects_for_user(conn.assigns.current_user)
@@ -42,9 +42,12 @@ defmodule Pairmotron.ProjectController do
     end
   end
 
-  def show(conn, %{"id" => id}) do
+  def show(conn = @authorized_conn, %{"id" => id}) do
     project = Repo.get!(Project, id) |> Repo.preload(:group)
     render(conn, "show.html", project: project)
+  end
+  def show(conn, _params) do
+    redirect_not_authorized(conn, project_path(conn, :index))
   end
 
   def edit(conn = @authorized_conn, _params) do

--- a/web/controllers/project_controller.ex
+++ b/web/controllers/project_controller.ex
@@ -32,6 +32,7 @@ defmodule Pairmotron.ProjectController do
         |> put_flash(:info, "Project created successfully.")
         |> redirect(to: project_path(conn, :index))
       {:error, changeset} ->
+        conn = assign(conn, :groups, groups)
         render(conn, "new.html", changeset: changeset)
     end
   end

--- a/web/controllers/project_controller.ex
+++ b/web/controllers/project_controller.ex
@@ -17,12 +17,14 @@ defmodule Pairmotron.ProjectController do
     groups = Group.groups_for_user(conn.assigns.current_user)
              |> Repo.all
     conn = assign(conn, :groups, groups)
-    changeset = Project.changeset_for_create(%Project{})
+    changeset = Project.changeset_for_create(%Project{}, %{}, groups)
     render(conn, "new.html", changeset: changeset)
   end
 
   def create(conn, %{"project" => project_params}) do
-    changeset = Project.changeset_for_create(%Project{}, project_params)
+    groups = Group.groups_for_user(conn.assigns.current_user)
+             |> Repo.all
+    changeset = Project.changeset_for_create(%Project{}, project_params, groups)
 
     case Repo.insert(changeset) do
       {:ok, _project} ->

--- a/web/controllers/project_controller.ex
+++ b/web/controllers/project_controller.ex
@@ -4,7 +4,8 @@ defmodule Pairmotron.ProjectController do
   alias Pairmotron.Project
 
   def index(conn, _params) do
-    projects = Repo.all(Project)
+    projects = Repo.all(Project.projects_for_user(conn.assigns.current_user))
+               |> Repo.preload(:group)
     render(conn, "index.html", projects: projects)
   end
 

--- a/web/models/group.ex
+++ b/web/models/group.ex
@@ -5,6 +5,7 @@ defmodule Pairmotron.Group do
     field :name, :string
     belongs_to :owner, Pairmotron.User
     many_to_many :users, Pairmotron.User, join_through: Pairmotron.UserGroup
+    has_many :projects, Pairmotron.Project
 
     timestamps()
   end

--- a/web/models/group.ex
+++ b/web/models/group.ex
@@ -32,4 +32,10 @@ defmodule Pairmotron.Group do
     |> foreign_key_constraint(:owner_id)
     |> put_assoc(:users, users)
   end
+
+  def groups_for_user(user) do
+    from group in Pairmotron.Group,
+    join: u in assoc(group, :users),
+    where: u.id == ^user.id
+  end
 end

--- a/web/models/project.ex
+++ b/web/models/project.ex
@@ -27,10 +27,11 @@ defmodule Pairmotron.Project do
   @required_create_params ~w(name group_id)
   @optional_change_params ~w(description url)
 
-  def changeset_for_create(struct, params \\ %{}) do
+  def changeset_for_create(struct, params \\ %{}, users_groups) do
     struct
     |> cast(params, @required_create_params, @optional_change_params)
     |> validate_url(:url)
+    |> validate_user_is_in_group(:group_id, users_groups)
   end
 
 
@@ -46,6 +47,16 @@ defmodule Pairmotron.Project do
         %URI{scheme: nil} -> [{field, "URL is missing the scheme. Include 'http://' or 'https://'."}]
         %URI{host: nil} -> [{field, "URL is not valid."}]
         _ -> []
+      end
+    end
+  end
+
+  def validate_user_is_in_group(changeset, field, users_groups) do
+    validate_change changeset, field, fn _, selected_group_id ->
+      if users_groups |> Enum.any?(fn group -> group.id == selected_group_id end) do
+        []
+      else
+        [{field, "Must be member of group"}]
       end
     end
   end

--- a/web/models/project.ex
+++ b/web/models/project.ex
@@ -14,6 +14,7 @@ defmodule Pairmotron.Project do
 
   @required_params ~w(name)
   @optional_params ~w(description url group_id)
+  @optional_params_for_update ~w(description url)
 
   @doc """
   Builds a changeset based on the `struct` and `params`.
@@ -21,6 +22,12 @@ defmodule Pairmotron.Project do
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, @required_params, @optional_params)
+    |> validate_url(:url)
+  end
+
+  def changeset_for_update(struct, params \\ %{}) do
+    struct
+    |> cast(params, @required_params, @optional_params_for_update)
     |> validate_url(:url)
   end
 

--- a/web/models/project.ex
+++ b/web/models/project.ex
@@ -14,7 +14,6 @@ defmodule Pairmotron.Project do
 
   @required_params ~w(name)
   @optional_params ~w(description url group_id)
-  @optional_params_for_update ~w(description url)
 
   @doc """
   Builds a changeset based on the `struct` and `params`.
@@ -25,9 +24,19 @@ defmodule Pairmotron.Project do
     |> validate_url(:url)
   end
 
+  @required_create_params ~w(name group_id)
+  @optional_change_params ~w(description url)
+
+  def changeset_for_create(struct, params \\ %{}) do
+    struct
+    |> cast(params, @required_create_params, @optional_change_params)
+    |> validate_url(:url)
+  end
+
+
   def changeset_for_update(struct, params \\ %{}) do
     struct
-    |> cast(params, @required_params, @optional_params_for_update)
+    |> cast(params, @required_params, @optional_change_params)
     |> validate_url(:url)
   end
 

--- a/web/models/project.ex
+++ b/web/models/project.ex
@@ -7,6 +7,7 @@ defmodule Pairmotron.Project do
     field :url, :string
 
     has_many :pair_retros, Pairmotron.PairRetro
+    belongs_to :group, Pairmotron.Group
 
     timestamps()
   end

--- a/web/models/project.ex
+++ b/web/models/project.ex
@@ -13,7 +13,7 @@ defmodule Pairmotron.Project do
   end
 
   @required_params ~w(name)
-  @optional_params ~w(description url)
+  @optional_params ~w(description url group_id)
 
   @doc """
   Builds a changeset based on the `struct` and `params`.
@@ -32,5 +32,12 @@ defmodule Pairmotron.Project do
         _ -> []
       end
     end
+  end
+
+  def projects_for_user(user) do
+    from project in Pairmotron.Project,
+    join: group in assoc(project, :group),
+    join: u in assoc(group, :users),
+    where: u.id == ^user.id
   end
 end

--- a/web/templates/project/edit.html.eex
+++ b/web/templates/project/edit.html.eex
@@ -1,6 +1,7 @@
 <h2>Edit project</h2>
 
 <%= render "form.html", changeset: @changeset,
-                        action: project_path(@conn, :update, @project) %>
+                        action: project_path(@conn, :update, @project),
+                        groups: groups_for_select(@conn) %>
 
 <%= link "Back", to: project_path(@conn, :index) %>

--- a/web/templates/project/edit.html.eex
+++ b/web/templates/project/edit.html.eex
@@ -1,7 +1,6 @@
 <h2>Edit project</h2>
 
-<%= render "form.html", changeset: @changeset,
-                        action: project_path(@conn, :update, @project),
-                        groups: groups_for_select(@conn) %>
+<%= render "form_update.html", changeset: @changeset,
+                               action: project_path(@conn, :update, @project) %>
 
 <%= link "Back", to: project_path(@conn, :index) %>

--- a/web/templates/project/form.html.eex
+++ b/web/templates/project/form.html.eex
@@ -1,4 +1,4 @@
-<%= form_for @changeset, @action, fn f -> %>
+<%= form_for @changeset, @action, @groups, fn f -> %>
   <%= if @changeset.action do %>
     <div class="alert alert-danger">
       <p>Oops, something went wrong! Please check the errors below.</p>
@@ -21,6 +21,12 @@
     <%= label f, :url, class: "control-label" %>
     <%= text_input f, :url, class: "form-control" %>
     <%= error_tag f, :url %>
+  </div>
+
+  <div class="form-group">
+    <%= label f, :group_id, "Group", class: "control-label" %>
+    <%= select f, :group_id, @groups, prompt: "(none)", class: "form-control" %>
+    <%= error_tag f, :group_id %>
   </div>
 
   <div class="form-group">

--- a/web/templates/project/form_update.html.eex
+++ b/web/templates/project/form_update.html.eex
@@ -1,0 +1,29 @@
+<%= form_for @changeset, @action, fn f -> %>
+  <%= if @changeset.action do %>
+    <div class="alert alert-danger">
+      <p>Oops, something went wrong! Please check the errors below.</p>
+    </div>
+  <% end %>
+
+  <div class="form-group">
+    <%= label f, :name, class: "control-label" %>
+    <%= text_input f, :name, class: "form-control" %>
+    <%= error_tag f, :name %>
+  </div>
+
+  <div class="form-group">
+    <%= label f, :description, class: "control-label" %>
+    <%= text_input f, :description, class: "form-control" %>
+    <%= error_tag f, :description %>
+  </div>
+
+  <div class="form-group">
+    <%= label f, :url, class: "control-label" %>
+    <%= text_input f, :url, class: "form-control" %>
+    <%= error_tag f, :url %>
+  </div>
+
+  <div class="form-group">
+    <%= submit "Submit", class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/web/templates/project/index.html.eex
+++ b/web/templates/project/index.html.eex
@@ -34,9 +34,6 @@
             <%= link "Edit", to: project_path(@conn, :edit, project), class: "btn btn-default btn-xs" %>
             <%= link "Delete", to: project_path(@conn, :delete, project), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs" %>
           <%= end %>
-        <%= else %>
-          <%= link "Edit", to: project_path(@conn, :edit, project), class: "btn btn-default btn-xs" %>
-          <%= link "Delete", to: project_path(@conn, :delete, project), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs" %>
         <%= end %>
       </td>
     </tr>

--- a/web/templates/project/index.html.eex
+++ b/web/templates/project/index.html.eex
@@ -5,8 +5,9 @@
     <tr>
       <th>Name</th>
       <th>Description</th>
+      <th>Group</th>
 
-      <th></th>
+      <th />
     </tr>
   </thead>
   <tbody>
@@ -20,11 +21,23 @@
         <%= end %>
       </td>
       <td><%= project.description %></td>
+      <td>
+        <%= if project.group do %>
+          <%= project.group.name %>
+        <%= end %>
+      </td>
 
       <td class="text-right">
         <%= link "Show", to: project_path(@conn, :show, project), class: "btn btn-default btn-xs" %>
-        <%= link "Edit", to: project_path(@conn, :edit, project), class: "btn btn-default btn-xs" %>
-        <%= link "Delete", to: project_path(@conn, :delete, project), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs" %>
+        <%= if project.group do %>
+          <%=  if project.group.owner_id == @conn.assigns.current_user.id do %>
+            <%= link "Edit", to: project_path(@conn, :edit, project), class: "btn btn-default btn-xs" %>
+            <%= link "Delete", to: project_path(@conn, :delete, project), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs" %>
+          <%= end %>
+        <%= else %>
+          <%= link "Edit", to: project_path(@conn, :edit, project), class: "btn btn-default btn-xs" %>
+          <%= link "Delete", to: project_path(@conn, :delete, project), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs" %>
+        <%= end %>
       </td>
     </tr>
 <% end %>

--- a/web/templates/project/new.html.eex
+++ b/web/templates/project/new.html.eex
@@ -1,6 +1,7 @@
 <h2>New project</h2>
 
 <%= render "form.html", changeset: @changeset,
-                        action: project_path(@conn, :create) %>
+                        action: project_path(@conn, :create),
+                        groups: groups_for_select(@conn) %>
 
 <%= link "Back", to: project_path(@conn, :index) %>

--- a/web/templates/project/no_groups.html.eex
+++ b/web/templates/project/no_groups.html.eex
@@ -1,0 +1,14 @@
+<p>
+  <strong>
+    Projects have to be associated with groups. It looks like you aren't in a group. Find a group to join or create your own!
+  </strong>
+</p>
+
+<p>
+  <a href=<%= group_path(@conn, :index) %>>
+    <button class="btn btn-primary">Find Group</button>
+  </a>
+  <a href=<%= group_path(@conn, :new) %>>
+    <button class="btn btn-primary">Create Group</button>
+  </a>
+</p>

--- a/web/templates/project/show.html.eex
+++ b/web/templates/project/show.html.eex
@@ -16,6 +16,11 @@
     <%= @project.description %>
   </li>
 
+  <li>
+    <strong>Group:</strong>
+    <%= format_group(@project.group) %>
+  </li>
+
 </ul>
 
 <%= link "Edit", to: project_path(@conn, :edit, @project), class: "padded-link" %>

--- a/web/views/project_view.ex
+++ b/web/views/project_view.ex
@@ -1,3 +1,13 @@
 defmodule Pairmotron.ProjectView do
   use Pairmotron.Web, :view
+
+  def groups_for_select(conn) do
+    case conn.assigns[:projects] do
+      nil -> []
+      projects ->
+        projects
+        |> Enum.map(&["#{&1.name}": &1.id])
+        |> List.flatten
+    end
+  end
 end

--- a/web/views/project_view.ex
+++ b/web/views/project_view.ex
@@ -1,11 +1,14 @@
 defmodule Pairmotron.ProjectView do
   use Pairmotron.Web, :view
 
+  def format_group(nil), do: "(none)"
+  def format_group(%Pairmotron.Group{name: name}), do: name
+
   def groups_for_select(conn) do
-    case conn.assigns[:projects] do
+    case conn.assigns[:groups] do
       nil -> []
-      projects ->
-        projects
+      groups ->
+        groups
         |> Enum.map(&["#{&1.name}": &1.id])
         |> List.flatten
     end


### PR DESCRIPTION
Adds a group relation to projects so that users in groups can have projects that are private to that group.

Users can create projects as long as they are associated with at least one group. If they are not they are directed to a screen where they can either create or find a different group (I realized actually joining someone else's group is not implemented yet).

Once a project has been created, the group that it's associated with can never be changed (except with /admin).

TODO:

- [x] Setup Project form to allow a selection of the Group to be associated with a project.
  - [x] This dropdown should only list groups that the current user is associated with.
- [x] Make selection of group only available when creating a project
  - [x] for the update route
  - [x] for the edit form
- [x] Disable the ability to hit the project :create action with a group_id that the current user is not associated with. (i.e. add validation to the changeset)
- [x] Make the group required upon creation and update
- [x] If a user isn't a member of any groups tell them that they have to join/create a group in order to make a project since projects have to be associated with groups.