### PR TITLE
Add created_by to project model and db table

### DIFF
--- a/lib/abilities.ex
+++ b/lib/abilities.ex
@@ -26,8 +26,12 @@ defimpl Canada.Can, for: Pairmotron.User do
 
   def can?(%User{id: user_id}, action, project = %Project{})
     when action in [:edit, :update, :delete] do
-    project = project |> Pairmotron.Repo.preload(:group)
-    project.group.owner_id == user_id
+    project = project |> Pairmotron.Repo.preload([{:group, :users}])
+    cond do
+      project.group.owner_id == user_id -> true
+      project.created_by_id == user_id -> true
+      true -> false
+    end
   end
 
   def can?(%User{}, _, _), do: false

--- a/lib/abilities.ex
+++ b/lib/abilities.ex
@@ -29,6 +29,7 @@ defimpl Canada.Can, for: Pairmotron.User do
     project = project |> Pairmotron.Repo.preload([{:group, :users}])
     cond do
       project.group.owner_id == user_id -> true
+      !Enum.any?(project.group.users, &(&1.id == user_id)) -> false
       project.created_by_id == user_id -> true
       true -> false
     end

--- a/priv/repo/migrations/20170203194544_add_created_by_to_project.exs
+++ b/priv/repo/migrations/20170203194544_add_created_by_to_project.exs
@@ -1,0 +1,9 @@
+defmodule Pairmotron.Repo.Migrations.AddCreatedByToRetro do
+  use Ecto.Migration
+
+  def change do
+    alter table(:projects) do
+      add :created_by_id, references(:users, on_delete: :nilify_all)
+    end
+  end
+end

--- a/test/controllers/project_controller_test.exs
+++ b/test/controllers/project_controller_test.exs
@@ -130,6 +130,14 @@ defmodule Pairmotron.ProjectControllerTest do
       assert html_response(conn, 200) =~ "Edit project"
     end
 
+    test "allows edit of project if user created project and is still in associated group but is not owner",
+      %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{users: [user]})
+      project = insert(:project, %{group: group, created_by: user})
+      conn = get conn, project_path(conn, :edit, project)
+      assert html_response(conn, 200) =~ "Edit project"
+    end
+
     test "does not allow edit of project if user is in associated group but not owner", %{conn: conn, logged_in_user: user} do
       group = insert(:group, %{users: [user]})
       project = insert(:project, %{group: group})
@@ -153,6 +161,15 @@ defmodule Pairmotron.ProjectControllerTest do
     test "updates project if user is owner of associated group", %{conn: conn, logged_in_user: user} do
       group = insert(:group, %{owner: user, users: [user]})
       project = insert(:project, %{group: group})
+      conn = put conn, project_path(conn, :update, project), project: @valid_attrs
+      assert redirected_to(conn) == project_path(conn, :show, project)
+      assert Repo.get_by(Project, @valid_attrs)
+    end
+
+    test "updates project if user created project and is still in associated group but is not owner",
+      %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{users: [user]})
+      project = insert(:project, %{group: group, created_by: user})
       conn = put conn, project_path(conn, :update, project), project: @valid_attrs
       assert redirected_to(conn) == project_path(conn, :show, project)
       assert Repo.get_by(Project, @valid_attrs)
@@ -200,6 +217,15 @@ defmodule Pairmotron.ProjectControllerTest do
     test "deletes project if user is owner of associated group", %{conn: conn, logged_in_user: user} do
       group = insert(:group, %{owner: user, users: [user]})
       project = insert(:project, %{group: group})
+      conn = delete conn, project_path(conn, :delete, project)
+      assert redirected_to(conn) == project_path(conn, :index)
+      refute Repo.get(Project, project.id)
+    end
+
+    test "deletes project if user created project and is still in associated group but is not owner",
+      %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{users: [user]})
+      project = insert(:project, %{group: group, created_by: user})
       conn = delete conn, project_path(conn, :delete, project)
       assert redirected_to(conn) == project_path(conn, :index)
       refute Repo.get(Project, project.id)

--- a/test/views/project_view_test.exs
+++ b/test/views/project_view_test.exs
@@ -1,0 +1,26 @@
+defmodule Pairmotron.ProjectViewTest do
+  use Pairmotron.ConnCase, async: true
+  alias Pairmotron.ProjectView
+
+  describe ".user_can_edit_project?" do
+    test "creator of project can edit project" do
+      user = insert(:user)
+      project = insert(:project, %{created_by: user})
+      assert ProjectView.user_can_edit_project?(project, user) == true
+    end
+
+    test "owner of project's group can edit project" do
+      user = insert(:user)
+      group = insert(:group, %{owner: user, users: [user]})
+      project = insert(:project, %{group: group})
+      assert ProjectView.user_can_edit_project?(project, user) == true
+    end
+
+    test "regular user in group cannot edit project when not creator" do
+      user = insert(:user)
+      group = insert(:group, %{users: [user]})
+      project = insert(:project, %{group: group})
+      assert ProjectView.user_can_edit_project?(project, user) == false
+    end
+  end
+end

--- a/web/controllers/project_controller.ex
+++ b/web/controllers/project_controller.ex
@@ -27,8 +27,10 @@ defmodule Pairmotron.ProjectController do
   end
 
   def create(conn, %{"project" => project_params}) do
-    groups = Group.groups_for_user(conn.assigns.current_user)
-             |> Repo.all
+    current_user = conn.assigns.current_user
+
+    groups = Group.groups_for_user(current_user) |> Repo.all
+    project_params = project_params |> Map.put("created_by_id", current_user.id)
     changeset = Project.changeset_for_create(%Project{}, project_params, groups)
 
     case Repo.insert(changeset) do

--- a/web/models/project.ex
+++ b/web/models/project.ex
@@ -8,6 +8,7 @@ defmodule Pairmotron.Project do
 
     has_many :pair_retros, Pairmotron.PairRetro
     belongs_to :group, Pairmotron.Group
+    belongs_to :created_by, Pairmotron.User
 
     timestamps()
   end

--- a/web/models/project.ex
+++ b/web/models/project.ex
@@ -14,7 +14,7 @@ defmodule Pairmotron.Project do
   end
 
   @required_params ~w(name)
-  @optional_params ~w(description url group_id)
+  @optional_params ~w(description url group_id created_by_id)
 
   @doc """
   Builds a changeset based on the `struct` and `params`.
@@ -25,7 +25,7 @@ defmodule Pairmotron.Project do
     |> validate_url(:url)
   end
 
-  @required_create_params ~w(name group_id)
+  @required_create_params ~w(name group_id created_by_id)
   @optional_change_params ~w(description url)
 
   def changeset_for_create(struct, params \\ %{}, users_groups) do

--- a/web/templates/project/index.html.eex
+++ b/web/templates/project/index.html.eex
@@ -30,7 +30,7 @@
       <td class="text-right">
         <%= link "Show", to: project_path(@conn, :show, project), class: "btn btn-default btn-xs" %>
         <%= if project.group do %>
-          <%=  if project.group.owner_id == @conn.assigns.current_user.id do %>
+          <%= if user_can_edit_project?(project, @conn.assigns.current_user) do %>
             <%= link "Edit", to: project_path(@conn, :edit, project), class: "btn btn-default btn-xs" %>
             <%= link "Delete", to: project_path(@conn, :delete, project), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs" %>
           <%= end %>

--- a/web/views/project_view.ex
+++ b/web/views/project_view.ex
@@ -13,4 +13,15 @@ defmodule Pairmotron.ProjectView do
         |> List.flatten
     end
   end
+
+  @doc """
+  True if the given user is the creator of the project or is the owner of the
+  group associated with the project. False otherwise.
+
+  Expects the :group association on project to be preloaded or else the function
+  will error.
+  """
+  def user_can_edit_project?(project, user) do
+    project.created_by_id == user.id or project.group.owner_id == user.id
+  end
 end


### PR DESCRIPTION
Adds a created_by field to the project model so that the original creator of a project can edit it in the future in addition to the owner of the project's associated group.

TODO:
- [x] Setup Model/DB Migration
- [x] Set created_by upon creation of a project
- [x] Allow the creator of a project to edit/update/delete if they are still in the group
- [x] Ensure that the creator of a project cannot edit/update/delete if they are no longer in the group
- [x] Enable the edit and delete buttons on the project index if the current user is the creator of that specific project even if they are not the owner of the associated group.

Closes #86 