### PR TITLE
Fix registration not signing in with Guardian

### DIFF
--- a/web/controllers/registration_controller.ex
+++ b/web/controllers/registration_controller.ex
@@ -16,7 +16,7 @@ defmodule Pairmotron.RegistrationController do
       {:ok, user} ->
         conn
         |> put_flash(:info, "Successfully registered and logged in")
-        |> put_session(:current_user_id, user.id)
+        |> Guardian.Plug.sign_in(user)
         |> redirect(to: pair_path(conn, :index))
       {:error, changeset} ->
         render conn, "new.html", changeset: changeset


### PR DESCRIPTION
Fixes a registration session bug where it was signing in using Plug.conn.put_session rather than Guardian.sign_in.

Closes #93 