### PR TITLE
91 add group membership request

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -49,7 +49,8 @@ config :ex_admin,
     Pairmotron.ExAdmin.Group,
     Pairmotron.ExAdmin.Project,
     Pairmotron.ExAdmin.User,
-    Pairmotron.ExAdmin.UserGroup
+    Pairmotron.ExAdmin.UserGroup,
+    Pairmotron.ExAdmin.GroupMembershipRequest
   ]
 
 # Import environment specific config. This must remain at the bottom

--- a/priv/repo/migrations/20170206182420_create_group_membership_request.exs
+++ b/priv/repo/migrations/20170206182420_create_group_membership_request.exs
@@ -1,0 +1,14 @@
+defmodule Pairmotron.Repo.Migrations.CreateGroupMembershipRequest do
+  use Ecto.Migration
+
+  def change do
+    create table(:group_membership_request) do
+      add :user_id, references(:users, on_delete: :delete_all), null: false
+      add :group_id, references(:groups, on_delete: :delete_all), null: false
+      add :initiated_by_user, :boolean, null: false
+
+      timestamps()
+    end
+
+  end
+end

--- a/priv/repo/migrations/20170206182420_create_group_membership_request.exs
+++ b/priv/repo/migrations/20170206182420_create_group_membership_request.exs
@@ -2,13 +2,15 @@ defmodule Pairmotron.Repo.Migrations.CreateGroupMembershipRequest do
   use Ecto.Migration
 
   def change do
-    create table(:group_membership_request) do
+    create table(:group_membership_requests) do
       add :user_id, references(:users, on_delete: :delete_all), null: false
       add :group_id, references(:groups, on_delete: :delete_all), null: false
       add :initiated_by_user, :boolean, null: false
 
       timestamps()
     end
+
+    create unique_index(:group_membership_requests, [:user_id, :group_id])
 
   end
 end

--- a/test/controllers/group_controller_test.exs
+++ b/test/controllers/group_controller_test.exs
@@ -68,6 +68,12 @@ defmodule Pairmotron.GroupControllerTest do
       refute html_response(conn, 200) =~ group_path(conn, :edit, group)
     end
 
+    test "shows link to request membership if user is not in group", %{conn: conn} do
+      group = insert(:group)
+      conn = get conn, group_path(conn, :show, group)
+      assert html_response(conn, 200) =~ "Request Membership"
+    end
+
     test "shows invitations link when user is group owner", %{conn: conn, logged_in_user: user} do
       group = insert(:group, %{owner: user, users: [user]})
       conn = get conn, group_path(conn, :show, group)
@@ -79,6 +85,12 @@ defmodule Pairmotron.GroupControllerTest do
       conn = get conn, group_path(conn, :show, group)
       assert html_response(conn, 200) =~ "Edit Group"
       assert html_response(conn, 200) =~ group_path(conn, :edit, group)
+    end
+
+    test "does not show link to request membership if user is in group", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{users: [user]})
+      conn = get conn, group_path(conn, :show, group)
+      refute html_response(conn, 200) =~ "Request Membership"
     end
 
     test "renders page not found when id is nonexistent", %{conn: conn} do

--- a/test/controllers/group_controller_test.exs
+++ b/test/controllers/group_controller_test.exs
@@ -58,7 +58,7 @@ defmodule Pairmotron.GroupControllerTest do
     test "does not show invitations link if user is not group owner", %{conn: conn} do
       group = insert(:group)
       conn = get conn, group_path(conn, :show, group)
-      refute html_response(conn, 200) =~ group_invitation_path(conn, :index, group) 
+      refute html_response(conn, 200) =~ group_invitation_path(conn, :index, group)
     end
 
     test "does not show edit group link if user is not group owner", %{conn: conn} do
@@ -77,7 +77,7 @@ defmodule Pairmotron.GroupControllerTest do
     test "shows invitations link when user is group owner", %{conn: conn, logged_in_user: user} do
       group = insert(:group, %{owner: user, users: [user]})
       conn = get conn, group_path(conn, :show, group)
-      assert html_response(conn, 200) =~ group_invitation_path(conn, :index, group) 
+      assert html_response(conn, 200) =~ group_invitation_path(conn, :index, group)
     end
 
     test "shows edit group link when user is group owner", %{conn: conn, logged_in_user: user} do
@@ -91,6 +91,23 @@ defmodule Pairmotron.GroupControllerTest do
       group = insert(:group, %{users: [user]})
       conn = get conn, group_path(conn, :show, group)
       refute html_response(conn, 200) =~ "Request Membership"
+      assert html_response(conn, 200) =~ "Member"
+    end
+
+    test "shows invitation pending if user has requested membership", %{conn: conn, logged_in_user: user} do
+      group = insert(:group)
+      insert(:group_membership_request, %{group_id: group.id, user_id: user.id, initiated_by_user: true})
+      conn = get conn, group_path(conn, :show, group)
+      assert html_response(conn, 200) =~ "Invitation Pending..."
+    end
+
+    test "shows accept invitation link if user has been invited", %{conn: conn, logged_in_user: user} do
+      group = insert(:group)
+      group_membership_request = insert(:group_membership_request,
+        %{group_id: group.id, user_id: user.id, initiated_by_user: false})
+      conn = get conn, group_path(conn, :show, group)
+      assert html_response(conn, 200) =~ "Accept Invitation"
+      assert html_response(conn, 200) =~ users_group_membership_request_path(conn, :update, group_membership_request)
     end
 
     test "renders page not found when id is nonexistent", %{conn: conn} do

--- a/test/controllers/group_controller_test.exs
+++ b/test/controllers/group_controller_test.exs
@@ -58,25 +58,27 @@ defmodule Pairmotron.GroupControllerTest do
     test "does not show invitations link if user is not group owner", %{conn: conn} do
       group = insert(:group)
       conn = get conn, group_path(conn, :show, group)
-      refute html_response(conn, 200) =~ "Invitations"
+      refute html_response(conn, 200) =~ group_invitation_path(conn, :index, group) 
     end
 
     test "does not show edit group link if user is not group owner", %{conn: conn} do
       group = insert(:group)
       conn = get conn, group_path(conn, :show, group)
       refute html_response(conn, 200) =~ "Edit Group"
+      refute html_response(conn, 200) =~ group_path(conn, :edit, group)
     end
 
     test "shows invitations link when user is group owner", %{conn: conn, logged_in_user: user} do
       group = insert(:group, %{owner: user, users: [user]})
       conn = get conn, group_path(conn, :show, group)
-      assert html_response(conn, 200) =~ "Invitations"
+      assert html_response(conn, 200) =~ group_invitation_path(conn, :index, group) 
     end
 
     test "shows edit group link when user is group owner", %{conn: conn, logged_in_user: user} do
       group = insert(:group, %{owner: user, users: [user]})
       conn = get conn, group_path(conn, :show, group)
       assert html_response(conn, 200) =~ "Edit Group"
+      assert html_response(conn, 200) =~ group_path(conn, :edit, group)
     end
 
     test "renders page not found when id is nonexistent", %{conn: conn} do

--- a/test/controllers/group_controller_test.exs
+++ b/test/controllers/group_controller_test.exs
@@ -55,6 +55,30 @@ defmodule Pairmotron.GroupControllerTest do
       assert html_response(conn, 200) =~ "Show group"
     end
 
+    test "does not show invitations link if user is not group owner", %{conn: conn} do
+      group = insert(:group)
+      conn = get conn, group_path(conn, :show, group)
+      refute html_response(conn, 200) =~ "Invitations"
+    end
+
+    test "does not show edit group link if user is not group owner", %{conn: conn} do
+      group = insert(:group)
+      conn = get conn, group_path(conn, :show, group)
+      refute html_response(conn, 200) =~ "Edit Group"
+    end
+
+    test "shows invitations link when user is group owner", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{owner: user, users: [user]})
+      conn = get conn, group_path(conn, :show, group)
+      assert html_response(conn, 200) =~ "Invitations"
+    end
+
+    test "shows edit group link when user is group owner", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{owner: user, users: [user]})
+      conn = get conn, group_path(conn, :show, group)
+      assert html_response(conn, 200) =~ "Edit Group"
+    end
+
     test "renders page not found when id is nonexistent", %{conn: conn} do
       assert_error_sent 404, fn ->
         get conn, group_path(conn, :show, -1)
@@ -106,8 +130,8 @@ defmodule Pairmotron.GroupControllerTest do
       assert redirected_to(conn) == group_path(conn, :index)
       assert Repo.get(Group, group.id)
     end
-
   end
+
   describe "as admin" do
     setup do
       user = insert(:user_admin)
@@ -119,6 +143,18 @@ defmodule Pairmotron.GroupControllerTest do
       group = insert(:group, owner: user)
       conn = get conn, group_path(conn, :edit, group)
       assert html_response(conn, 200) =~ "Edit group"
+    end
+
+    test "shows invitations link even if user is not group owner", %{conn: conn} do
+      group = insert(:group)
+      conn = get conn, group_path(conn, :show, group)
+      assert html_response(conn, 200) =~ "Invitations"
+    end
+
+    test "shows edit group link even if user is not group owner", %{conn: conn} do
+      group = insert(:group)
+      conn = get conn, group_path(conn, :show, group)
+      assert html_response(conn, 200) =~ "Edit Group"
     end
 
     test "admin may update a group not owned by admin", %{conn: conn} do

--- a/test/controllers/group_invitation_controller_test.exs
+++ b/test/controllers/group_invitation_controller_test.exs
@@ -155,7 +155,7 @@ defmodule Pairmotron.GroupInvitationControllerTest do
       attrs = %{user_id: other_user.id}
       conn = post conn, group_invitation_path(conn, :create, group), group_membership_request: attrs
 
-      assert redirected_to(conn) == group_invitation_path(conn, :index, group)
+      assert html_response(conn, 200) =~ "User is already in this group"
       refute Repo.get_by(GroupMembershipRequest, %{group_id: group.id, user_id: other_user.id})
     end
 
@@ -166,9 +166,8 @@ defmodule Pairmotron.GroupInvitationControllerTest do
       attrs = %{user_id: other_user.id}
       conn = post conn, group_invitation_path(conn, :create, group), group_membership_request: attrs
 
-      assert redirected_to(conn) == group_invitation_path(conn, :index, group)
+      assert html_response(conn, 200) =~ "User is already invited to this group"
       assert 1 = Repo.all(GroupMembershipRequest) |> length
-      assert %{private: %{phoenix_flash: %{"error" => _}}} = conn
     end
 
     test "errors without a user_id param", %{conn: conn, logged_in_user: user} do

--- a/test/controllers/group_invitation_controller_test.exs
+++ b/test/controllers/group_invitation_controller_test.exs
@@ -61,6 +61,34 @@ defmodule Pairmotron.GroupInvitationControllerTest do
     end
   end
 
+  describe "using :new while authenticated" do
+    setup do
+      user = insert(:user)
+      conn = build_conn() |> log_in(user)
+      {:ok, [conn: conn, logged_in_user: user]}
+    end
+
+    test "renders invitation form if user is owner of group", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{owner: user, users: [user]})
+      conn = get conn, group_invitation_path(conn, :new, group)
+      assert html_response(conn, 200) =~ "Invite user to"
+      assert html_response(conn, 200) =~ group.name
+    end
+
+    test "form can select user who is not in group", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{owner: user, users: [user]})
+      other_user = insert(:user)
+      conn = get conn, group_invitation_path(conn, :new, group)
+      assert html_response(conn, 200) =~ other_user.name
+    end
+
+    #test "form cannot select user who is already in group", %{conn: conn, logged_in_user: user} do
+      #group = insert(:group, %{owner: user, users: [user]})
+      #conn = get conn, group_invitation_path(conn, :new, group)
+      #refute html_response(conn, 200) =~ user.name
+    #end
+
+  end
   describe "using :create while authenticated" do
     setup do
       user = insert(:user)

--- a/test/controllers/group_invitation_controller_test.exs
+++ b/test/controllers/group_invitation_controller_test.exs
@@ -82,13 +82,14 @@ defmodule Pairmotron.GroupInvitationControllerTest do
       assert html_response(conn, 200) =~ other_user.name
     end
 
-    #test "form cannot select user who is already in group", %{conn: conn, logged_in_user: user} do
-      #group = insert(:group, %{owner: user, users: [user]})
-      #conn = get conn, group_invitation_path(conn, :new, group)
-      #refute html_response(conn, 200) =~ user.name
-    #end
-
+    test "form cannot select user who is already in group", %{conn: conn, logged_in_user: user} do
+      other_user = insert(:user)
+      group = insert(:group, %{owner: user, users: [user, other_user]})
+      conn = get conn, group_invitation_path(conn, :new, group)
+      refute html_response(conn, 200) =~ other_user.name
+    end
   end
+
   describe "using :create while authenticated" do
     setup do
       user = insert(:user)

--- a/test/controllers/group_invitation_controller_test.exs
+++ b/test/controllers/group_invitation_controller_test.exs
@@ -38,7 +38,7 @@ defmodule Pairmotron.GroupInvitationControllerTest do
       conn = get conn, group_invitation_path(conn, :index, group)
       assert html_response(conn, 200) =~ user.name
       assert html_response(conn, 200) =~ "Accept Membership Request"
-      assert html_response(conn, 200) =~ group_invitation_path(conn, :update, group_membership_request, group.id)
+      assert html_response(conn, 200) =~ group_invitation_path(conn, :update, group.id, group_membership_request)
     end
 
     test "does not list invitations not associated with the group", %{conn: conn, group: group} do

--- a/test/controllers/group_invitation_controller_test.exs
+++ b/test/controllers/group_invitation_controller_test.exs
@@ -88,6 +88,18 @@ defmodule Pairmotron.GroupInvitationControllerTest do
       conn = get conn, group_invitation_path(conn, :new, group)
       refute html_response(conn, 200) =~ other_user.name
     end
+
+    test "redirects if logged in user in group but not owner of group", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{users: [user]})
+      conn = get conn, group_invitation_path(conn, :new, group)
+      assert redirected_to(conn) == group_invitation_path(conn, :index, group)
+    end
+
+    test "redirects if logged in user is not owner of group", %{conn: conn} do
+      group = insert(:group)
+      conn = get conn, group_invitation_path(conn, :new, group)
+      assert redirected_to(conn) == group_invitation_path(conn, :index, group)
+    end
   end
 
   describe "using :create while authenticated" do

--- a/test/controllers/group_invitation_controller_test.exs
+++ b/test/controllers/group_invitation_controller_test.exs
@@ -169,17 +169,6 @@ defmodule Pairmotron.GroupInvitationControllerTest do
       assert html_response(conn, 200) =~ "User is already invited to this group"
       assert 1 = Repo.all(GroupMembershipRequest) |> length
     end
-
-    test "errors without a user_id param", %{conn: conn, logged_in_user: user} do
-      group = insert(:group, %{owner: user, users: [user]})
-      conn = post conn, group_invitation_path(conn, :create, group), group_membership_request: %{}
-      assert html_response(conn, 404) =~ "not found"
-    end
-
-    test "handles nonexistent group", %{conn: conn} do
-      conn = post conn, group_invitation_path(conn, :create, 123), group_membership_request: %{}
-      assert html_response(conn, 404) =~ "not found"
-    end
   end
 
   describe "using :update while authenticated" do

--- a/test/controllers/group_invitation_controller_test.exs
+++ b/test/controllers/group_invitation_controller_test.exs
@@ -1,0 +1,63 @@
+defmodule Pairmotron.GroupInvitationControllerTest do
+  use Pairmotron.ConnCase
+
+  alias Pairmotron.{GroupMembershipRequest, UserGroup}
+
+  import Pairmotron.TestHelper, only: [log_in: 2]
+
+  test "redirects to sign-in when not logged in", %{conn: conn} do
+    group = insert(:group)
+    conn = get conn, group_invitation_path(conn, :index, group.id)
+    assert redirected_to(conn) == session_path(conn, :new)
+  end
+
+  describe "using :index while authenticated" do
+    setup do
+      user = insert(:user)
+      conn = build_conn() |> log_in(user)
+      group = insert(:group, %{owner: user, users: [user]})
+      {:ok, [conn: conn, logged_in_user: user, group: group]}
+    end
+
+    test "states that there are no active group invitations when there are not", %{conn: conn, group: group} do
+      conn = get conn, group_invitation_path(conn, :index, group.id)
+      assert html_response(conn, 200) =~ "There are no active invitations for this group at this time"
+    end
+
+    test "lists an invitation that is associated with the group", %{conn: conn, group: group} do
+      user = insert(:user)
+      insert(:group_membership_request, %{user: user, group: group, initiated_by_user: false})
+      conn = get conn, group_invitation_path(conn, :index, group.id)
+      assert html_response(conn, 200) =~ user.name
+      assert html_response(conn, 200) =~ "Awaiting Response"
+    end
+
+    test "lists an invitation initiated by user and links to accept the invitation", %{conn: conn, group: group} do
+      user = insert(:user)
+      group_membership_request = insert(:group_membership_request, %{user: user, group: group, initiated_by_user: true})
+      conn = get conn, group_invitation_path(conn, :index, group.id)
+      assert html_response(conn, 200) =~ user.name
+      assert html_response(conn, 200) =~ "Accept Membership Request"
+      assert html_response(conn, 200) =~ group_invitation_path(conn, :update, group_membership_request, group.id)
+    end
+
+    test "does not list invitations not associated with the group", %{conn: conn, group: group} do
+      user = insert(:user)
+      other_group = insert(:group)
+      insert(:group_membership_request, %{user: user, group: other_group, initiated_by_user: false})
+      conn = get conn, group_invitation_path(conn, :index, group.id)
+      assert html_response(conn, 200) =~ "There are no active invitations for this group at this time"
+    end
+
+    test "does not list invitations if user is not owner of group", %{conn: conn} do
+      group = insert(:group)
+      conn = get conn, group_invitation_path(conn, :index, group.id)
+      assert redirected_to(conn) == group_path(conn, :show, group)
+    end
+
+    test "handles nonexistent group", %{conn: conn} do
+      conn = get conn, group_invitation_path(conn, :index, 1)
+      assert html_response(conn, 404) =~ "not found"
+    end
+  end
+end

--- a/test/controllers/users_group_membership_request_controller_test.exs
+++ b/test/controllers/users_group_membership_request_controller_test.exs
@@ -1,6 +1,8 @@
 defmodule Pairmotron.UsersGroupMembershipRequestControllerTest do
   use Pairmotron.ConnCase
 
+  alias Pairmotron.{GroupMembershipRequest, UserGroup}
+
   import Pairmotron.TestHelper, only: [log_in: 2]
 
   test "redirects to sign-in when not logged in", %{conn: conn} do
@@ -8,7 +10,7 @@ defmodule Pairmotron.UsersGroupMembershipRequestControllerTest do
     assert redirected_to(conn) == session_path(conn, :new)
   end
 
-  describe "while authenticated" do
+  describe "using :index while authenticated" do
     setup do
       user = insert(:user)
       conn = build_conn() |> log_in(user)
@@ -44,6 +46,113 @@ defmodule Pairmotron.UsersGroupMembershipRequestControllerTest do
       assert html_response(conn, 200) =~ "Invited by Group"
       assert html_response(conn, 200) =~ "Accept Invitation"
       refute html_response(conn, 200) =~ "You have no active invitations at this time"
+    end
+  end
+
+  describe "using :create while authenticated" do
+    setup do
+      user = insert(:user)
+      conn = build_conn() |> log_in(user)
+      {:ok, [conn: conn, logged_in_user: user]}
+    end
+
+    test "can create a group_membership_request", %{conn: conn, logged_in_user: user} do
+      group = insert(:group)
+      attrs = %{group_id: group.id}
+      conn = post conn, users_group_membership_request_path(conn, :create), group_membership_request: attrs
+      assert redirected_to(conn) == users_group_membership_request_path(conn, :index)
+      assert Repo.get_by(GroupMembershipRequest, %{group_id: group.id, user_id: user.id, initiated_by_user: true})
+    end
+
+    test "cannot inject a different user into params", %{conn: conn, logged_in_user: user} do
+      group = insert(:group)
+      other_user = insert(:user)
+      attrs = %{group_id: group.id, user_id: other_user.id}
+      post conn, users_group_membership_request_path(conn, :create), group_membership_request: attrs
+      assert Repo.get_by(GroupMembershipRequest, %{group_id: group.id, user_id: user.id, initiated_by_user: true})
+      refute Repo.get_by(GroupMembershipRequest, %{group_id: group.id, user_id: other_user.id, initiated_by_user: true})
+    end
+
+    test "cannot inject initiated_by_user of false into params", %{conn: conn, logged_in_user: user} do
+      group = insert(:group)
+      attrs = %{group_id: group.id, initiated_by_user: false}
+      post conn, users_group_membership_request_path(conn, :create), group_membership_request: attrs
+      assert Repo.get_by(GroupMembershipRequest, %{group_id: group.id, user_id: user.id, initiated_by_user: true})
+      refute Repo.get_by(GroupMembershipRequest, %{group_id: group.id, user_id: user.id, initiated_by_user: false})
+    end
+
+    test "errors if a group_membership_request without group_id param", %{conn: conn, logged_in_user: user} do
+      post conn, users_group_membership_request_path(conn, :create), group_membership_request: %{}
+      refute Repo.get_by(GroupMembershipRequest, %{user_id: user.id})
+    end
+
+    test "errors if a group_membership_request if user is already in group", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{users: [user]})
+      attrs = %{group_id: group.id}
+      post conn, users_group_membership_request_path(conn, :create), group_membership_request: attrs
+      refute Repo.get_by(GroupMembershipRequest, %{group_id: group.id, user_id: user.id, initiated_by_user: true})
+    end
+
+    test "errors if a group_membership_request already exists for that user", %{conn: conn, logged_in_user: user} do
+      group = insert(:group)
+      attrs = %{group_id: group.id}
+      insert(:group_membership_request, %{group_id: group.id, user_id: user.id, initiated_by_user: true})
+      conn = post conn, users_group_membership_request_path(conn, :create), group_membership_request: attrs
+      assert redirected_to(conn) == users_group_membership_request_path(conn, :index)
+    end
+  end
+
+  describe "using :update while authenticated" do
+    setup do
+      user = insert(:user)
+      conn = build_conn() |> log_in(user)
+      {:ok, [conn: conn, logged_in_user: user]}
+    end
+
+    test "creates a group and deletes group_invite if group_invite exists created by group", %{conn: conn, logged_in_user: user} do
+      group = insert(:group)
+      group_membership_request = insert(:group_membership_request, %{group_id: group.id, user_id: user.id, initiated_by_user: false})
+      conn = put conn, users_group_membership_request_path(conn, :update, group_membership_request), group_membership_request: %{} 
+      assert redirected_to(conn) == users_group_membership_request_path(conn, :index)
+      refute Repo.get(GroupMembershipRequest, group_membership_request.id)
+      assert Repo.get_by(UserGroup, %{group_id: group.id, user_id: user.id})
+    end
+
+    test "redirects if group_membership_request doesn't exist", %{conn: conn, logged_in_user: user} do
+      group = insert(:group)
+      group_membership_request = build(:group_membership_request, %{group_id: group.id, user_id: user.id, initiated_by_user: false})
+      group_membership_request = %{group_membership_request | id: 123} # otherwise id is nil
+      conn = put conn, users_group_membership_request_path(conn, :update, group_membership_request), group_membership_request: %{} 
+      assert html_response(conn, 404) =~ "Page not found"
+      refute Repo.get_by(UserGroup, %{group_id: group.id, user_id: user.id})
+    end
+
+    test "redirects if logged in user is not in group_membership_request", %{conn: conn, logged_in_user: user} do
+      group = insert(:group)
+      other_user = insert(:user)
+      group_membership_request = insert(:group_membership_request, %{group_id: group.id, user_id: other_user.id, initiated_by_user: false})
+      conn = put conn, users_group_membership_request_path(conn, :update, group_membership_request), group_membership_request: %{} 
+      assert redirected_to(conn) == users_group_membership_request_path(conn, :index)
+      assert Repo.get(GroupMembershipRequest, group_membership_request.id)
+      refute Repo.get_by(UserGroup, %{group_id: group.id, user_id: user.id})
+      refute Repo.get_by(UserGroup, %{group_id: group.id, user_id: other_user.id})
+    end
+
+    test "redirects and deletes group_membership_request if logged in user is already in the group", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{users: [user]})
+      group_membership_request = insert(:group_membership_request, %{group_id: group.id, user_id: user.id, initiated_by_user: false})
+      conn = put conn, users_group_membership_request_path(conn, :update, group_membership_request), group_membership_request: %{} 
+      assert redirected_to(conn) == users_group_membership_request_path(conn, :index)
+      refute Repo.get(GroupMembershipRequest, group_membership_request.id)
+    end
+
+    test "does not create user_group if invitation created by user", %{conn: conn, logged_in_user: user} do
+      group = insert(:group)
+      group_membership_request = insert(:group_membership_request, %{group_id: group.id, user_id: user.id, initiated_by_user: true})
+      conn = put conn, users_group_membership_request_path(conn, :update, group_membership_request), group_membership_request: %{}
+      assert redirected_to(conn) == users_group_membership_request_path(conn, :index)
+      assert Repo.get(GroupMembershipRequest, group_membership_request.id)
+      refute Repo.get_by(UserGroup, %{group_id: group.id, user_id: user.id})
     end
   end
 end

--- a/test/controllers/users_group_membership_request_controller_test.exs
+++ b/test/controllers/users_group_membership_request_controller_test.exs
@@ -27,7 +27,6 @@ defmodule Pairmotron.UsersGroupMembershipRequestControllerTest do
       insert(:group_membership_request, %{initiated_by_user: true, user: user, group: group})
       conn = get conn, users_group_membership_request_path(conn, :index)
 
-      assert html_response(conn, 200) =~ "User Requested"
       assert html_response(conn, 200) =~ "Awaiting Response"
       refute html_response(conn, 200) =~ "You have no active invitations at this time"
     end
@@ -46,7 +45,6 @@ defmodule Pairmotron.UsersGroupMembershipRequestControllerTest do
       group_membership_request = insert(:group_membership_request, %{initiated_by_user: false, user: user, group: group})
       conn = get conn, users_group_membership_request_path(conn, :index)
 
-      assert html_response(conn, 200) =~ "Invited by Group"
       assert html_response(conn, 200) =~ "Accept Invitation"
       assert html_response(conn, 200) =~ users_group_membership_request_path(conn, :update, group_membership_request)
       refute html_response(conn, 200) =~ "You have no active invitations at this time"

--- a/test/controllers/users_group_membership_request_controller_test.exs
+++ b/test/controllers/users_group_membership_request_controller_test.exs
@@ -1,0 +1,49 @@
+defmodule Pairmotron.UsersGroupMembershipRequestControllerTest do
+  use Pairmotron.ConnCase
+
+  import Pairmotron.TestHelper, only: [log_in: 2]
+
+  test "redirects to sign-in when not logged in", %{conn: conn} do
+    conn = get conn, users_group_membership_request_path(conn, :index)
+    assert redirected_to(conn) == session_path(conn, :new)
+  end
+
+  describe "while authenticated" do
+    setup do
+      user = insert(:user)
+      conn = build_conn() |> log_in(user)
+      {:ok, [conn: conn, logged_in_user: user]}
+    end
+
+    test "states that there are no active invitations when there are not", %{conn: conn} do
+      conn = get conn, users_group_membership_request_path(conn, :index)
+      assert html_response(conn, 200) =~ "You have no active invitations at this time"
+    end
+
+    test "user generated request displays on index properly", %{conn: conn, logged_in_user: user} do
+      group = insert(:group)
+      insert(:group_membership_request, %{initiated_by_user: true, user: user, group: group})
+      conn = get conn, users_group_membership_request_path(conn, :index)
+      assert html_response(conn, 200) =~ "User Requested"
+      assert html_response(conn, 200) =~ "Awaiting Response"
+      refute html_response(conn, 200) =~ "You have no active invitations at this time"
+    end
+
+    test "does not list other users invitations", %{conn: conn} do
+      user = insert(:user)
+      group = insert(:group)
+      insert(:group_membership_request, %{initiated_by_user: true, user: user, group: group})
+      conn = get conn, users_group_membership_request_path(conn, :index)
+      assert html_response(conn, 200) =~ "You have no active invitations at this time"
+    end
+
+    test "group generated request displays on index properly", %{conn: conn, logged_in_user: user} do
+      group = insert(:group)
+      insert(:group_membership_request, %{initiated_by_user: false, user: user, group: group})
+      conn = get conn, users_group_membership_request_path(conn, :index)
+      assert html_response(conn, 200) =~ "Invited by Group"
+      assert html_response(conn, 200) =~ "Accept Invitation"
+      refute html_response(conn, 200) =~ "You have no active invitations at this time"
+    end
+  end
+end

--- a/test/controllers/users_group_membership_request_controller_test.exs
+++ b/test/controllers/users_group_membership_request_controller_test.exs
@@ -81,12 +81,12 @@ defmodule Pairmotron.UsersGroupMembershipRequestControllerTest do
       refute Repo.get_by(GroupMembershipRequest, %{group_id: group.id, user_id: user.id, initiated_by_user: false})
     end
 
-    test "errors if a group_membership_request without group_id param", %{conn: conn, logged_in_user: user} do
+    test "errors without group_id param", %{conn: conn, logged_in_user: user} do
       post conn, users_group_membership_request_path(conn, :create), group_membership_request: %{}
       refute Repo.get_by(GroupMembershipRequest, %{user_id: user.id})
     end
 
-    test "errors if a group_membership_request if user is already in group", %{conn: conn, logged_in_user: user} do
+    test "errors if user is already in group", %{conn: conn, logged_in_user: user} do
       group = insert(:group, %{users: [user]})
       attrs = %{group_id: group.id}
       post conn, users_group_membership_request_path(conn, :create), group_membership_request: attrs
@@ -98,7 +98,10 @@ defmodule Pairmotron.UsersGroupMembershipRequestControllerTest do
       attrs = %{group_id: group.id}
       insert(:group_membership_request, %{group_id: group.id, user_id: user.id, initiated_by_user: true})
       conn = post conn, users_group_membership_request_path(conn, :create), group_membership_request: attrs
+
       assert redirected_to(conn) == users_group_membership_request_path(conn, :index)
+      assert 1 = Repo.all(GroupMembershipRequest) |> length
+      assert %{private: %{phoenix_flash: %{"error" => _}}} = conn
     end
   end
 

--- a/test/controllers/users_group_membership_request_controller_test.exs
+++ b/test/controllers/users_group_membership_request_controller_test.exs
@@ -43,11 +43,12 @@ defmodule Pairmotron.UsersGroupMembershipRequestControllerTest do
 
     test "group generated request displays on index properly", %{conn: conn, logged_in_user: user} do
       group = insert(:group)
-      insert(:group_membership_request, %{initiated_by_user: false, user: user, group: group})
+      group_membership_request = insert(:group_membership_request, %{initiated_by_user: false, user: user, group: group})
       conn = get conn, users_group_membership_request_path(conn, :index)
 
       assert html_response(conn, 200) =~ "Invited by Group"
       assert html_response(conn, 200) =~ "Accept Invitation"
+      assert html_response(conn, 200) =~ users_group_membership_request_path(conn, :update, group_membership_request)
       refute html_response(conn, 200) =~ "You have no active invitations at this time"
     end
   end

--- a/test/models/group_membership_request_test.exs
+++ b/test/models/group_membership_request_test.exs
@@ -1,0 +1,21 @@
+defmodule Pairmotron.GroupMembershipRequestTest do
+  use Pairmotron.ModelCase
+
+  alias Pairmotron.GroupMembershipRequest
+
+  @valid_attrs %{initiated_by_user: true}
+  @invalid_attrs %{}
+
+  test "changeset with valid attributes" do
+    user = insert(:user)
+    group = insert(:group)
+    attrs = Map.merge(@valid_attrs, %{user_id: user.id, group_id: group.id})
+    changeset = GroupMembershipRequest.changeset(%GroupMembershipRequest{}, attrs)
+    assert changeset.valid?
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = GroupMembershipRequest.changeset(%GroupMembershipRequest{}, @invalid_attrs)
+    refute changeset.valid?
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -49,4 +49,8 @@ defmodule Pairmotron.Factory do
       users: []
     }
   end
+
+  def group_membership_request_factory do
+    %Pairmotron.GroupMembershipRequest{}
+  end
 end

--- a/web/admin/group_membership_request.ex
+++ b/web/admin/group_membership_request.ex
@@ -1,0 +1,7 @@
+defmodule Pairmotron.ExAdmin.GroupMembershipRequest do
+  use ExAdmin.Register
+
+  register_resource Pairmotron.GroupMembershipRequest do
+    filter [:user, :group, :initiated_by_user]
+  end
+end

--- a/web/controllers/group_controller.ex
+++ b/web/controllers/group_controller.ex
@@ -1,7 +1,7 @@
 defmodule Pairmotron.GroupController do
   use Pairmotron.Web, :controller
 
-  alias Pairmotron.Group
+  alias Pairmotron.{Group, GroupMembershipRequest}
   import Pairmotron.ControllerHelpers
 
   plug :load_and_authorize_resource, model: Group, only: [:edit, :update, :delete]
@@ -34,7 +34,10 @@ defmodule Pairmotron.GroupController do
 
   def show(conn, %{"id" => id}) do
     group = Repo.get!(Group, id) |> Repo.preload(:owner)
-    render(conn, "show.html", group: group)
+    invite_changeset = GroupMembershipRequest.changeset(%GroupMembershipRequest{}, %{group_id: id})
+    current_user = conn.assigns.current_user |> Repo.preload(:groups)
+    conn = conn |> Plug.Conn.assign(:current_user, current_user)
+    render(conn, "show.html", group: group, invite_changeset: invite_changeset)
   end
 
   def edit(conn = @authorized_conn, _params) do

--- a/web/controllers/group_controller.ex
+++ b/web/controllers/group_controller.ex
@@ -35,7 +35,7 @@ defmodule Pairmotron.GroupController do
   def show(conn, %{"id" => id}) do
     group = Repo.get!(Group, id) |> Repo.preload(:owner)
     invite_changeset = GroupMembershipRequest.changeset(%GroupMembershipRequest{}, %{group_id: id})
-    current_user = conn.assigns.current_user |> Repo.preload(:groups)
+    current_user = conn.assigns.current_user |> Repo.preload([:groups, :group_membership_requests])
     conn = conn |> Plug.Conn.assign(:current_user, current_user)
     render(conn, "show.html", group: group, invite_changeset: invite_changeset)
   end

--- a/web/controllers/group_invitation_controller.ex
+++ b/web/controllers/group_invitation_controller.ex
@@ -1,7 +1,7 @@
 defmodule Pairmotron.GroupInvitationController do
   use Pairmotron.Web, :controller
 
-  alias Pairmotron.{Group, GroupMembershipRequest, UserGroup}
+  alias Pairmotron.{Group, GroupMembershipRequest, User, UserGroup}
   import Pairmotron.ControllerHelpers
 
   def index(conn, %{"group_id" => group_id}) do
@@ -16,14 +16,57 @@ defmodule Pairmotron.GroupInvitationController do
     else
       handle_resource_not_found(conn)
     end
-
   end
 
-  def create(conn, %{"group_membership_request" => group_membership_request_params}) do
-    conn
+  def create(conn, %{"group_id" => group_id, "group_membership_request" => group_membership_request_params}) do
+    current_user = conn.assigns.current_user
+
+    {group_id_int, _} = Integer.parse(group_id)
+    group = preloaded_group_or_nil(group_id_int)
+
+    user_id = parameter_as_integer(group_membership_request_params, "user_id")
+    user = Repo.get(User, user_id)
+
+    cond do
+      is_nil(user) ->
+        handle_resource_not_found(conn)
+      is_nil(group) ->
+        handle_resource_not_found(conn)
+      group.owner_id != current_user.id ->
+        redirect_and_flash_error(conn, "You must be the owner of a group to invite user to that group", group_id)
+      user in group.users ->
+        redirect_and_flash_error(conn, "Cannot invite user that is already in group", group_id)
+      true ->
+        implicit_params = %{"initiated_by_user" => false, "group_id" => group_id}
+        final_params = Map.merge(group_membership_request_params, implicit_params)
+        changeset = GroupMembershipRequest.changeset(%GroupMembershipRequest{}, final_params)
+
+        case Repo.insert(changeset) do
+          {:ok, _group_membership_request} ->
+            #Repo.all(GroupMembershipRequest) |> IO.inspect
+            conn
+            |> put_flash(:info, "Sent invitation to join group successfully.")
+            |> redirect(to: group_invitation_path(conn, :index, group_id))
+          {:error, _changeset} ->
+            redirect_and_flash_error(conn, "Error inviting to group", group_id)
+        end
+    end
   end
 
   def update(conn, %{"group_membership_request" => _params}) do
     conn
+  end
+
+  defp preloaded_group_or_nil(group_id) do
+    group = case Repo.get(Group, group_id) do
+      nil -> nil
+      group -> Repo.preload(group, :users)
+    end
+  end
+
+  defp redirect_and_flash_error(conn, message, group_id) do
+    conn
+    |> put_flash(:error, message)
+    |> redirect(to: group_invitation_path(conn, :index, group_id))
   end
 end

--- a/web/controllers/group_invitation_controller.ex
+++ b/web/controllers/group_invitation_controller.ex
@@ -21,10 +21,15 @@ defmodule Pairmotron.GroupInvitationController do
   end
 
   def new(conn, %{"group_id" => group_id}) do
-    changeset = GroupMembershipRequest.changeset(%GroupMembershipRequest{}, %{})
     group = Repo.get!(Group, group_id)
-    invitable_users = invitable_users_for_select(group)
-    render(conn, "new.html", changeset: changeset, group: group, invitable_users: invitable_users)
+    cond do
+      group.owner_id != conn.assigns.current_user.id ->
+        redirect_and_flash_error(conn, "You must be the owner of a group to invite user to that group", group_id)
+      true ->
+        changeset = GroupMembershipRequest.changeset(%GroupMembershipRequest{}, %{})
+        invitable_users = invitable_users_for_select(group)
+        render(conn, "new.html", changeset: changeset, group: group, invitable_users: invitable_users)
+    end
   end
 
   def create(conn, %{"group_id" => group_id, "group_membership_request" => group_membership_request_params}) do

--- a/web/controllers/group_invitation_controller.ex
+++ b/web/controllers/group_invitation_controller.ex
@@ -55,7 +55,7 @@ defmodule Pairmotron.GroupInvitationController do
     end
   end
 
-  def update(conn, %{"group_membership_request" => _params}) do
+  def update(conn, %{}) do
     group_membership_request = conn.assigns.group_membership_request |> Repo.preload([:user, :group])
     user = group_membership_request.user
     group = group_membership_request.group

--- a/web/controllers/group_invitation_controller.ex
+++ b/web/controllers/group_invitation_controller.ex
@@ -1,0 +1,29 @@
+defmodule Pairmotron.GroupInvitationController do
+  use Pairmotron.Web, :controller
+
+  alias Pairmotron.{Group, GroupMembershipRequest, UserGroup}
+  import Pairmotron.ControllerHelpers
+
+  def index(conn, %{"group_id" => group_id}) do
+    group = Repo.get(Group, group_id)
+    if group do
+      group = group |> Repo.preload([{:group_membership_requests, :user}])
+      if group.owner_id == conn.assigns.current_user.id do
+        render(conn, "index.html", group_membership_requests: group.group_membership_requests)
+      else
+        redirect_not_authorized(conn, group_path(conn, :show, group))
+      end
+    else
+      handle_resource_not_found(conn)
+    end
+
+  end
+
+  def create(conn, %{"group_membership_request" => group_membership_request_params}) do
+    conn
+  end
+
+  def update(conn, %{"group_membership_request" => _params}) do
+    conn
+  end
+end

--- a/web/controllers/users_group_membership_request_controller.ex
+++ b/web/controllers/users_group_membership_request_controller.ex
@@ -1,8 +1,10 @@
 defmodule Pairmotron.UsersGroupMembershipRequestController do
   use Pairmotron.Web, :controller
 
-  alias Pairmotron.{Group, GroupMembershipRequest, User}
+  alias Pairmotron.{Group, GroupMembershipRequest, UserGroup}
   import Pairmotron.ControllerHelpers
+
+  plug :load_resource, model: GroupMembershipRequest, only: [:update]
 
   def index(conn, _params) do
     group_membership_requests =
@@ -11,5 +13,77 @@ defmodule Pairmotron.UsersGroupMembershipRequestController do
       |> Repo.all
       |> Repo.preload(:group)
     render(conn, "index.html", group_membership_requests: group_membership_requests)
+  end
+
+  def create(conn, %{"group_membership_request" => group_membership_request_params}) do
+    current_user = conn.assigns.current_user
+    group_id = parameter_as_integer(group_membership_request_params, "group_id")
+
+    cond do
+      user_is_in_group?(current_user, group_id) ->
+        redirect_and_flash_error(conn, "User already in group")
+      true ->
+        implicit_params = %{"user_id" => current_user.id, "initiated_by_user" => true}
+        final_params = Map.merge(group_membership_request_params, implicit_params)
+        changeset = GroupMembershipRequest.changeset(%GroupMembershipRequest{}, final_params)
+
+        case Repo.insert(changeset) do
+          {:ok, _project} ->
+            conn
+            |> put_flash(:info, "Sent request to join group successfully.")
+            |> redirect(to: users_group_membership_request_path(conn, :index))
+          {:error, _changeset} ->
+            redirect_and_flash_error(conn, "Error requesting group membership")
+        end
+    end
+  end
+
+  def update(conn, %{"group_membership_request" => _params}) do
+    group_membership_request = conn.assigns.group_membership_request
+    user = conn.assigns.current_user
+
+    cond do
+      group_membership_request.user_id != user.id ->
+        redirect_and_flash_error(conn, "Cannot accept invitation for other user")
+      group_membership_request.initiated_by_user == true ->
+        redirect_and_flash_error(conn, "Cannot accept invitation created by user")
+      true ->
+        user_group_changeset = UserGroup.changeset(%UserGroup{},
+                                                   %{user_id: user.id, 
+                                                     group_id: group_membership_request.group_id})
+
+        transaction = update_transaction(group_membership_request, user_group_changeset)
+        case Repo.transaction(transaction) do
+          {:ok, _} ->
+            conn
+            |> put_flash(:info, "You have successfully joined group")
+            |> redirect(to: users_group_membership_request_path(conn, :index))
+          {:error, :group_membership_request, _, _} ->
+            redirect_and_flash_error(conn, "Error removing invitation")
+          {:error, :user_group, %{errors: [user_id_group_id: _]}, _} ->
+            Repo.delete!(group_membership_request)
+            redirect_and_flash_error(conn, "You are already in that group!")
+          {:error, :user_group, _, _} ->
+            redirect_and_flash_error(conn, "Error adding user to group")
+        end
+    end
+  end
+
+  defp user_is_in_group?(user, group_id) do
+    group = Repo.get(Group, group_id)
+    user = user |> Repo.preload(:groups)
+    group in user.groups
+  end
+
+  defp redirect_and_flash_error(conn, message) do
+    conn
+    |> put_flash(:error, message)
+    |> redirect(to: users_group_membership_request_path(conn, :index))
+  end
+
+  defp update_transaction(group_membership_request, user_group_changeset) do
+    Ecto.Multi.new
+    |> Ecto.Multi.delete(:group_membership_request, group_membership_request)
+    |> Ecto.Multi.insert(:user_group, user_group_changeset)
   end
 end

--- a/web/controllers/users_group_membership_request_controller.ex
+++ b/web/controllers/users_group_membership_request_controller.ex
@@ -38,7 +38,7 @@ defmodule Pairmotron.UsersGroupMembershipRequestController do
     end
   end
 
-  def update(conn, %{"group_membership_request" => _params}) do
+  def update(conn, %{}) do
     group_membership_request = conn.assigns.group_membership_request
     user = conn.assigns.current_user
 

--- a/web/controllers/users_group_membership_request_controller.ex
+++ b/web/controllers/users_group_membership_request_controller.ex
@@ -1,0 +1,15 @@
+defmodule Pairmotron.UsersGroupMembershipRequestController do
+  use Pairmotron.Web, :controller
+
+  alias Pairmotron.{Group, GroupMembershipRequest, User}
+  import Pairmotron.ControllerHelpers
+
+  def index(conn, _params) do
+    group_membership_requests =
+      conn.assigns.current_user
+      |> assoc(:group_membership_requests)
+      |> Repo.all
+      |> Repo.preload(:group)
+    render(conn, "index.html", group_membership_requests: group_membership_requests)
+  end
+end

--- a/web/controllers/users_group_membership_request_controller.ex
+++ b/web/controllers/users_group_membership_request_controller.ex
@@ -28,7 +28,7 @@ defmodule Pairmotron.UsersGroupMembershipRequestController do
         changeset = GroupMembershipRequest.changeset(%GroupMembershipRequest{}, final_params)
 
         case Repo.insert(changeset) do
-          {:ok, _project} ->
+          {:ok, _group_membership_request} ->
             conn
             |> put_flash(:info, "Sent request to join group successfully.")
             |> redirect(to: users_group_membership_request_path(conn, :index))

--- a/web/models/group.ex
+++ b/web/models/group.ex
@@ -6,6 +6,7 @@ defmodule Pairmotron.Group do
     belongs_to :owner, Pairmotron.User
     many_to_many :users, Pairmotron.User, join_through: Pairmotron.UserGroup
     has_many :projects, Pairmotron.Project
+    has_many :group_membership_requests, Pairmotron.GroupMembershipRequest
 
     timestamps()
   end

--- a/web/models/group_membership_request.ex
+++ b/web/models/group_membership_request.ex
@@ -20,6 +20,22 @@ defmodule Pairmotron.GroupMembershipRequest do
     |> cast(params, @required_params, @optional_params)
     |> foreign_key_constraint(:user_id)
     |> foreign_key_constraint(:group_id)
-    |> unique_constraint(:user_id_group_id, [:user_id, :group_id])
+    |> unique_constraint(:user_id_group_id, [message: "User is already invited to this group"])
+  end
+
+  def users_changeset(struct, params \\ %{}, group) do
+    changeset(struct, params)
+    |> validate_user_not_in_group(:user_id, group)
+  end
+
+  def validate_user_not_in_group(changeset, field, group) do
+    validate_change changeset, field, fn _, user_id ->
+      groups_user_ids = Enum.map(group.users, &(&1.id))
+      cond do
+        user_id in groups_user_ids ->
+          [{field, "User is already in this group"}]
+        true -> []
+      end
+    end
   end
 end

--- a/web/models/group_membership_request.ex
+++ b/web/models/group_membership_request.ex
@@ -1,0 +1,24 @@
+defmodule Pairmotron.GroupMembershipRequest do
+  use Pairmotron.Web, :model
+
+  schema "group_membership_request" do
+    field :initiated_by_user, :boolean
+    belongs_to :user, Pairmotron.User
+    belongs_to :group, Pairmotron.Group
+
+    timestamps()
+  end
+
+  @required_params ~w(initiated_by_user user_id group_id)
+  @optional_params ~w()
+
+  @doc """
+  Builds a changeset based on the `struct` and `params`.
+  """
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, @required_params, @optional_params)
+    |> foreign_key_constraint(:user_id)
+    |> foreign_key_constraint(:group_id)
+  end
+end

--- a/web/models/group_membership_request.ex
+++ b/web/models/group_membership_request.ex
@@ -20,5 +20,6 @@ defmodule Pairmotron.GroupMembershipRequest do
     |> cast(params, @required_params, @optional_params)
     |> foreign_key_constraint(:user_id)
     |> foreign_key_constraint(:group_id)
+    |> unique_constraint(:user_id_group_id, [:user_id, :group_id])
   end
 end

--- a/web/models/group_membership_request.ex
+++ b/web/models/group_membership_request.ex
@@ -3,7 +3,7 @@ defmodule Pairmotron.GroupMembershipRequest do
 
   alias Pairmotron.GroupMembershipRequest
 
-  schema "group_membership_request" do
+  schema "group_membership_requests" do
     field :initiated_by_user, :boolean
     belongs_to :user, Pairmotron.User
     belongs_to :group, Pairmotron.Group

--- a/web/models/group_membership_request.ex
+++ b/web/models/group_membership_request.ex
@@ -1,8 +1,6 @@
 defmodule Pairmotron.GroupMembershipRequest do
   use Pairmotron.Web, :model
 
-  alias Pairmotron.GroupMembershipRequest
-
   schema "group_membership_requests" do
     field :initiated_by_user, :boolean
     belongs_to :user, Pairmotron.User

--- a/web/models/group_membership_request.ex
+++ b/web/models/group_membership_request.ex
@@ -1,6 +1,8 @@
 defmodule Pairmotron.GroupMembershipRequest do
   use Pairmotron.Web, :model
 
+  alias Pairmotron.GroupMembershipRequest
+
   schema "group_membership_request" do
     field :initiated_by_user, :boolean
     belongs_to :user, Pairmotron.User

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -13,6 +13,7 @@ defmodule Pairmotron.User do
 
     has_many :pair_retros, Pairmotron.PairRetro
     many_to_many :groups, Pairmotron.Group, join_through: "users_groups"
+    has_many :group_membership_requests, Pairmotron.GroupMembershipRequest
 
     timestamps()
   end

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -69,4 +69,17 @@ defmodule Pairmotron.User do
     Pairmotron.User
     |> Ecto.Query.where([u], u.active)
   end
+
+  def users_not_in_group(%Pairmotron.Group{} = group), do: users_not_in_group(group.id)
+  def users_not_in_group(group_id) do
+    from user in Pairmotron.User,
+    order_by: user.name
+
+    #from retro in Pairmotron.PairRetro,
+    #join: p in assoc(retro, :pair),
+    #where: retro.user_id == ^user.id,
+    #where: p.year == ^year,
+    #where: p.week == ^week
+    
+  end
 end

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -73,13 +73,8 @@ defmodule Pairmotron.User do
   def users_not_in_group(%Pairmotron.Group{} = group), do: users_not_in_group(group.id)
   def users_not_in_group(group_id) do
     from user in Pairmotron.User,
+    left_join: user_group in Pairmotron.UserGroup, on: user_group.user_id == user.id and user_group.group_id == ^group_id,
+    where: is_nil(user_group.user_id),
     order_by: user.name
-
-    #from retro in Pairmotron.PairRetro,
-    #join: p in assoc(retro, :pair),
-    #where: retro.user_id == ^user.id,
-    #where: p.year == ^year,
-    #where: p.week == ^week
-
   end
 end

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -80,6 +80,6 @@ defmodule Pairmotron.User do
     #where: retro.user_id == ^user.id,
     #where: p.year == ^year,
     #where: p.week == ^week
-    
+
   end
 end

--- a/web/models/user_group.ex
+++ b/web/models/user_group.ex
@@ -17,5 +17,6 @@ defmodule Pairmotron.UserGroup do
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, @required_fields, @optional_fields)
+    |> unique_constraint(:user_id_group_id, [:user_id, :group_id])
   end
 end

--- a/web/router.ex
+++ b/web/router.ex
@@ -57,6 +57,7 @@ defmodule Pairmotron.Router do
     get "/groups/:id/pairs/:year/:week", GroupPairController, :show
     delete "/groups/:id/pairs/:year/:week", GroupPairController, :delete
     resources "/groups", GroupController
+    get "/invitations", UsersGroupMembershipRequestController, :index
 
     get "/pair_retros/new/:pair_id", PairRetroController, :new
     resources "/pair_retros", PairRetroController, except: [:new]

--- a/web/router.ex
+++ b/web/router.ex
@@ -56,8 +56,9 @@ defmodule Pairmotron.Router do
     get "/groups/:id/pairs", GroupPairController, :show
     get "/groups/:id/pairs/:year/:week", GroupPairController, :show
     delete "/groups/:id/pairs/:year/:week", GroupPairController, :delete
-    resources "/groups", GroupController
+    resources "/groups/:group_id/invitations", GroupInvitationController, only: [:index, :create, :update]
     resources "/invitations", UsersGroupMembershipRequestController, only: [:index, :create, :update]
+    resources "/groups", GroupController
 
     get "/pair_retros/new/:pair_id", PairRetroController, :new
     resources "/pair_retros", PairRetroController, except: [:new]

--- a/web/router.ex
+++ b/web/router.ex
@@ -56,7 +56,7 @@ defmodule Pairmotron.Router do
     get "/groups/:id/pairs", GroupPairController, :show
     get "/groups/:id/pairs/:year/:week", GroupPairController, :show
     delete "/groups/:id/pairs/:year/:week", GroupPairController, :delete
-    resources "/groups/:group_id/invitations", GroupInvitationController, only: [:index, :create, :update]
+    resources "/groups/:group_id/invitations", GroupInvitationController, only: [:index, :new, :create, :update]
     resources "/invitations", UsersGroupMembershipRequestController, only: [:index, :create, :update]
     resources "/groups", GroupController
 

--- a/web/router.ex
+++ b/web/router.ex
@@ -57,7 +57,7 @@ defmodule Pairmotron.Router do
     get "/groups/:id/pairs/:year/:week", GroupPairController, :show
     delete "/groups/:id/pairs/:year/:week", GroupPairController, :delete
     resources "/groups", GroupController
-    get "/invitations", UsersGroupMembershipRequestController, :index
+    resources "/invitations", UsersGroupMembershipRequestController, only: [:index, :create, :update]
 
     get "/pair_retros/new/:pair_id", PairRetroController, :new
     resources "/pair_retros", PairRetroController, except: [:new]

--- a/web/templates/group/index.html.eex
+++ b/web/templates/group/index.html.eex
@@ -15,7 +15,7 @@
 
       <td class="text-right">
         <%= link "Show", to: group_path(@conn, :show, group), class: "btn btn-default btn-xs" %>
-        <%= if user_can_edit_group?(@conn.assigns.current_user, group) do %>
+        <%= if current_user_can_edit_group?(@conn, group) do %>
           <%= link "Edit", to: group_path(@conn, :edit, group), class: "btn btn-default btn-xs" %>
           <%= link "Delete", to: group_path(@conn, :delete, group), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs" %>
         <%= end %>

--- a/web/templates/group/index.html.eex
+++ b/web/templates/group/index.html.eex
@@ -15,8 +15,10 @@
 
       <td class="text-right">
         <%= link "Show", to: group_path(@conn, :show, group), class: "btn btn-default btn-xs" %>
-        <%= link "Edit", to: group_path(@conn, :edit, group), class: "btn btn-default btn-xs" %>
-        <%= link "Delete", to: group_path(@conn, :delete, group), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs" %>
+        <%= if user_can_edit_group?(@conn.assigns.current_user, group) do %>
+          <%= link "Edit", to: group_path(@conn, :edit, group), class: "btn btn-default btn-xs" %>
+          <%= link "Delete", to: group_path(@conn, :delete, group), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs" %>
+        <%= end %>
       </td>
     </tr>
 <% end %>

--- a/web/templates/group/request_membership_form.html.eex
+++ b/web/templates/group/request_membership_form.html.eex
@@ -1,0 +1,8 @@
+<%= form_for @changeset, @action, fn f -> %>
+
+  <%= hidden_input f, :group_id, value: value_from_changeset(@changeset, :group_id) %>
+  
+  <div class="form-group">
+    <%= submit "Request Membership", class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/web/templates/group/show.html.eex
+++ b/web/templates/group/show.html.eex
@@ -14,7 +14,13 @@
 
 </ul>
 
-<%= if user_can_edit_group?(@conn.assigns.current_user, @group) do %>
+<%= if not current_user_in_group?(@conn, @group) do %>
+  <%= render "request_membership_form.html",
+        changeset: @invite_changeset,
+        action: users_group_membership_request_path(@conn, :create) %>
+<%= end %>
+
+<%= if current_user_can_edit_group?(@conn, @group) do %>
   <a href=<%= group_invitation_path(@conn, :index, @group) %>>
     <button class="btn btn-primary">Invitations</button>
   </a>

--- a/web/templates/group/show.html.eex
+++ b/web/templates/group/show.html.eex
@@ -14,10 +14,23 @@
 
 </ul>
 
-<%= if not current_user_in_group?(@conn, @group) do %>
-  <%= render "request_membership_form.html",
-        changeset: @invite_changeset,
-        action: users_group_membership_request_path(@conn, :create) %>
+<%= cond do %>
+  <%= current_user_has_been_invited_by_group?(@conn, @group) -> %>
+    <%= render Pairmotron.UsersGroupMembershipRequestView,
+          "accept_invitation_form.html",
+          conn: @conn,
+          action: users_group_membership_request_path(@conn, :update, current_user_group_membership_request_for_group(@conn, @group)) %>
+  <%= current_user_in_group?(@conn, @group) -> %>
+    <p><label class="label label-success">Member</label></p>
+  <%= current_user_has_requested_membership_to_group?(@conn, @group) -> %>
+    <p><label class="label label-warning">Invitation Pending...</label></p>
+  <%= true -> %>
+    <%= render "request_membership_form.html",
+          changeset: @invite_changeset,
+          action: users_group_membership_request_path(@conn, :create) %>
+<%= end %>
+
+<%= if not current_user_has_requested_membership_to_group?(@conn, @group) do %>
 <%= end %>
 
 <%= if current_user_can_edit_group?(@conn, @group) do %>

--- a/web/templates/group/show.html.eex
+++ b/web/templates/group/show.html.eex
@@ -30,9 +30,6 @@
           action: users_group_membership_request_path(@conn, :create) %>
 <%= end %>
 
-<%= if not current_user_has_requested_membership_to_group?(@conn, @group) do %>
-<%= end %>
-
 <%= if current_user_can_edit_group?(@conn, @group) do %>
   <a href=<%= group_invitation_path(@conn, :index, @group) %>>
     <button class="btn btn-primary">Invitations</button>

--- a/web/templates/group/show.html.eex
+++ b/web/templates/group/show.html.eex
@@ -14,5 +14,11 @@
 
 </ul>
 
-<%= link "Edit", to: group_path(@conn, :edit, @group) %>
-<%= link "Back", to: group_path(@conn, :index) %>
+<%= if user_can_edit_group?(@conn.assigns.current_user, @group) do %>
+  <a href=<%= group_invitation_path(@conn, :index, @group) %>>
+    <button class="btn btn-primary">Invitations</button>
+  </a>
+  <a href=<%= group_path(@conn, :edit, @group) %>>
+    <button class="btn btn-primary">Edit Group</button>
+  </a>
+<%= end %>

--- a/web/templates/group_invitation/accept_invitation_form.html.eex
+++ b/web/templates/group_invitation/accept_invitation_form.html.eex
@@ -1,5 +1,5 @@
-<%= form_for @conn, @action, [name: :accept, method: "PUT"], fn f -> %>
+<%= form_for @conn, @action, [as: :accept, method: "PUT"], fn _f -> %>
   <div class="form-group">
-    <%= submit "Accept Invitation", class: "btn btn-primary" %>
+    <%= submit "Accept Membership Request", class: "btn btn-primary" %>
   </div>
 <% end %>

--- a/web/templates/group_invitation/accept_invitation_form.html.eex
+++ b/web/templates/group_invitation/accept_invitation_form.html.eex
@@ -1,0 +1,5 @@
+<%= form_for @conn, @action, [name: :accept, method: "PUT"], fn f -> %>
+  <div class="form-group">
+    <%= submit "Accept Invitation", class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/web/templates/group_invitation/index.html.eex
+++ b/web/templates/group_invitation/index.html.eex
@@ -17,7 +17,9 @@
         <%= if group_membership_request.initiated_by_user do %>
           <td>User Requested</td>
           <td>
-            <%= link "Accept Membership Request", to: group_invitation_path(@conn, :update, group_membership_request, group_membership_request.group_id) %>
+            <%= render "accept_invitation_form.html",
+                  conn: @conn,
+                  action: group_invitation_path(@conn, :update, group_membership_request, group_membership_request.group_id) %>
           </td>
         <%= else %>
           <td>Invited by Group</td>

--- a/web/templates/group_invitation/index.html.eex
+++ b/web/templates/group_invitation/index.html.eex
@@ -4,7 +4,6 @@
   <thead>
     <tr>
       <th>User</th>
-      <th>Type</th>
       <th>Status</th>
     </tr>
   </thead>
@@ -15,14 +14,12 @@
           <%= group_membership_request.user.name %>
         </td>
         <%= if group_membership_request.initiated_by_user do %>
-          <td>User Requested</td>
           <td>
             <%= render "accept_invitation_form.html",
                   conn: @conn,
                   action: group_invitation_path(@conn, :update, group_membership_request.group_id, group_membership_request) %>
           </td>
         <%= else %>
-          <td>Invited by Group</td>
           <td>Awaiting Response</td>
         <%= end %>
       </tr>

--- a/web/templates/group_invitation/index.html.eex
+++ b/web/templates/group_invitation/index.html.eex
@@ -1,0 +1,32 @@
+<h2>Listing Group Invitations</h2>
+
+<table class="table">
+  <thead>
+    <tr>
+      <th>User</th>
+      <th>Type</th>
+      <th>Status</th>
+    </tr>
+  </thead>
+  <tbody>
+    <%= for group_membership_request <- @group_membership_requests do %>
+      <tr>
+        <td>
+          <%= group_membership_request.user.name %>
+        </td>
+        <%= if group_membership_request.initiated_by_user do %>
+          <td>User Requested</td>
+          <td>
+            <%= link "Accept Membership Request", to: group_invitation_path(@conn, :update, group_membership_request, group_membership_request.group_id) %>
+          </td>
+        <%= else %>
+          <td>Invited by Group</td>
+          <td>Awaiting Response</td>
+        <%= end %>
+      </tr>
+    <%= end %>
+  </tbody>
+</table>
+<%= if Enum.empty?(@group_membership_requests) do %>
+  There are no active invitations for this group at this time
+<%= end %>

--- a/web/templates/group_invitation/index.html.eex
+++ b/web/templates/group_invitation/index.html.eex
@@ -19,7 +19,7 @@
           <td>
             <%= render "accept_invitation_form.html",
                   conn: @conn,
-                  action: group_invitation_path(@conn, :update, group_membership_request, group_membership_request.group_id) %>
+                  action: group_invitation_path(@conn, :update, group_membership_request.group_id, group_membership_request) %>
           </td>
         <%= else %>
           <td>Invited by Group</td>

--- a/web/templates/group_invitation/index.html.eex
+++ b/web/templates/group_invitation/index.html.eex
@@ -30,5 +30,12 @@
   </tbody>
 </table>
 <%= if Enum.empty?(@group_membership_requests) do %>
-  There are no active invitations for this group at this time
+  <p>
+    There are no active invitations for this group at this time
+  </p>
 <%= end %>
+<p>
+  <a href=<%= group_invitation_path(@conn, :new, @group) %>>
+    <button class="btn btn-primary">Invite user to group</button>
+  </a>
+</p>

--- a/web/templates/group_invitation/new.html.eex
+++ b/web/templates/group_invitation/new.html.eex
@@ -1,0 +1,21 @@
+<h2>Invite user to <%= @group.name %></h3>
+
+<%= form_for @changeset, group_invitation_path(@conn, :create, @group), fn f -> %>
+  <%= if @changeset.action do %>
+    <div class="alert alert-danger">
+      <p>Oops, something went wrong! Please check the errors below.</p>
+    </div>
+  <% end %>
+
+  <div class="form-group">
+    <%= label f, :user_id, "User", class: "control-label" %>
+    <%= select f, :user_id, @invitable_users, prompt: "(none)", class: "form-control" %>
+    <%= error_tag f, :user_id %>
+  </div>
+
+  <div class="form-group">
+    <%= submit "Invite User", class: "btn btn-primary" %>
+  </div>
+<% end %>
+
+<%= link "Back", to: group_path(@conn, :show, @group) %>

--- a/web/templates/group_invitation/new.html.eex
+++ b/web/templates/group_invitation/new.html.eex
@@ -11,6 +11,7 @@
     <%= label f, :user_id, "User", class: "control-label" %>
     <%= select f, :user_id, @invitable_users, prompt: "(none)", class: "form-control" %>
     <%= error_tag f, :user_id %>
+    <%= error_tag f, :user_id_group_id %>
   </div>
 
   <div class="form-group">

--- a/web/templates/layout/app.html.eex
+++ b/web/templates/layout/app.html.eex
@@ -26,17 +26,24 @@
         </div>
         <div class="collapse navbar-collapse" id="navbar-collapse-1">
           <ul class="nav navbar-nav navbar-right">
-            <li><%= link "Pairs", to: pair_path(@conn, :index) %></li>
-            <li><%= link "Groups", to: group_path(@conn, :index) %></li>
-            <li><%= link "Projects", to: project_path(@conn, :index) %></li>
-            <li><%= link "My Retros", to: pair_retro_path(@conn, :index) %></li>
-            <li><%= link "Profile", to: profile_path(@conn, :show) %></li>
-              <%= case @conn.assigns[:current_user] do %>
-                <% nil -> %>
-                  <%= link "Login", class: "btn btn-success navbar-btn", role: "button", to: session_path(@conn, :new) %>
-                <% _current_user -> %>
-                  <li><%= link "Logout", to: session_path(@conn, :delete) %></li>
-              <% end %>
+            <%= if logged_in?(@conn) do %>
+              <li><%= link "Pairs", to: pair_path(@conn, :index) %></li>
+              <li><%= link "Groups", to: group_path(@conn, :index) %></li>
+              <li><%= link "Projects", to: project_path(@conn, :index) %></li>
+              <li><%= link "My Retros", to: pair_retro_path(@conn, :index) %></li>
+              <li class="dropdown" role="presentation">
+                <a href="#" class="dropdown-toggle" data-toggle="dropdown"><%= @conn.assigns.current_user.name %><span class="caret"></span></a>
+                <ul class="dropdown-menu">
+                  <li><%= link "Profile", to: profile_path(@conn, :show) %></li>
+                  <li><%= link "Invitations", to: users_group_membership_request_path(@conn, :index)%></li>
+                </ul>
+              </li>
+            <%= end %>
+            <%= if logged_in?(@conn) do %>
+              <li><%= link "Logout", to: session_path(@conn, :delete) %></li>
+            <%= else %>
+              <%= link "Login", class: "btn btn-success navbar-btn", role: "button", to: session_path(@conn, :new) %>
+            <%= end %>
           </ul>
         </div>
       </div>

--- a/web/templates/layout/app.html.eex
+++ b/web/templates/layout/app.html.eex
@@ -30,11 +30,11 @@
               <li><%= link "Pairs", to: pair_path(@conn, :index) %></li>
               <li><%= link "Groups", to: group_path(@conn, :index) %></li>
               <li><%= link "Projects", to: project_path(@conn, :index) %></li>
-              <li><%= link "My Retros", to: pair_retro_path(@conn, :index) %></li>
               <li class="dropdown" role="presentation">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown"><%= @conn.assigns.current_user.name %><span class="caret"></span></a>
                 <ul class="dropdown-menu">
                   <li><%= link "Profile", to: profile_path(@conn, :show) %></li>
+                  <li><%= link "Retrospectives", to: pair_retro_path(@conn, :index) %></li>
                   <li><%= link "Invitations", to: users_group_membership_request_path(@conn, :index)%></li>
                 </ul>
               </li>

--- a/web/templates/profile/show.html.eex
+++ b/web/templates/profile/show.html.eex
@@ -19,7 +19,7 @@
           </div>
         </div>
       </div>
-            <div class="panel-footer"><%= link "Edit", to: profile_path(@conn, :edit), class: "padded-link" %></div>
+      <div class="panel-footer"><%= link "Edit", to: profile_path(@conn, :edit), class: "padded-link" %></div>
     </div>
   </div>
   <div class="col-md-7 col-sm-12">

--- a/web/templates/users_group_membership_request/accept_invitation_form.html.eex
+++ b/web/templates/users_group_membership_request/accept_invitation_form.html.eex
@@ -1,4 +1,4 @@
-<%= form_for @conn, @action, [name: :accept, method: "PUT"], fn f -> %>
+<%= form_for @conn, @action, [as: :accept, method: "PUT"], fn _f -> %>
   <div class="form-group">
     <%= submit "Accept Invitation", class: "btn btn-primary" %>
   </div>

--- a/web/templates/users_group_membership_request/accept_invitation_form.html.eex
+++ b/web/templates/users_group_membership_request/accept_invitation_form.html.eex
@@ -1,0 +1,5 @@
+<%= form_for @conn, @action, [name: :accept, method: "PUT"], fn f -> %>
+  <div class="form-group">
+    <%= submit "Accept Invitation", class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/web/templates/users_group_membership_request/index.html.eex
+++ b/web/templates/users_group_membership_request/index.html.eex
@@ -19,7 +19,11 @@
           <td>Awaiting Response</td>
         <%= else %>
           <td>Invited by Group</td>
-          <td>Accept Invitation</td>
+          <td>
+            <a href=<%= users_group_membership_request_path(@conn, :update, group_membership_request) %>>
+              <button class="btn btn-primary">Accept Invitation</button>
+            </a>
+          </td>
         <%= end %>
       </tr>
     <%= end %>

--- a/web/templates/users_group_membership_request/index.html.eex
+++ b/web/templates/users_group_membership_request/index.html.eex
@@ -4,7 +4,6 @@
   <thead>
     <tr>
       <th>Group</th>
-      <th>Type</th>
       <th>Status</th>
     </tr>
   </thead>
@@ -15,10 +14,8 @@
           <%= link group_membership_request.group.name, to: group_path(@conn, :show, group_membership_request.group) %>
         </td>
         <%= if group_membership_request.initiated_by_user do %>
-          <td>User Requested</td>
           <td>Awaiting Response</td>
         <%= else %>
-          <td>Invited by Group</td>
           <td>
             <%= render "accept_invitation_form.html",
                   conn: @conn,

--- a/web/templates/users_group_membership_request/index.html.eex
+++ b/web/templates/users_group_membership_request/index.html.eex
@@ -20,9 +20,9 @@
         <%= else %>
           <td>Invited by Group</td>
           <td>
-            <a href=<%= users_group_membership_request_path(@conn, :update, group_membership_request) %>>
-              <button class="btn btn-primary">Accept Invitation</button>
-            </a>
+            <%= render "accept_invitation_form.html",
+                  conn: @conn,
+                  action: users_group_membership_request_path(@conn, :update, group_membership_request) %>
           </td>
         <%= end %>
       </tr>

--- a/web/templates/users_group_membership_request/index.html.eex
+++ b/web/templates/users_group_membership_request/index.html.eex
@@ -1,0 +1,30 @@
+<h2>Listing Group Invitations</h2>
+
+<table class="table">
+  <thead>
+    <tr>
+      <th>Group</th>
+      <th>Type</th>
+      <th>Status</th>
+    </tr>
+  </thead>
+  <tbody>
+    <%= for group_membership_request <- @group_membership_requests do %>
+      <tr>
+        <td>
+          <%= link group_membership_request.group.name, to: group_path(@conn, :show, group_membership_request.group) %>
+        </td>
+        <%= if group_membership_request.initiated_by_user do %>
+          <td>User Requested</td>
+          <td>Awaiting Response</td>
+        <%= else %>
+          <td>Invited by Group</td>
+          <td>Accept Invitation</td>
+        <%= end %>
+      </tr>
+    <%= end %>
+  </tbody>
+</table>
+<%= if Enum.empty?(@group_membership_requests) do %>
+  You have no active invitations at this time
+<%= end %>

--- a/web/views/group_invitation_view.ex
+++ b/web/views/group_invitation_view.ex
@@ -1,0 +1,3 @@
+defmodule Pairmotron.GroupInvitationView do
+  use Pairmotron.Web, :view
+end

--- a/web/views/group_view.ex
+++ b/web/views/group_view.ex
@@ -1,3 +1,7 @@
 defmodule Pairmotron.GroupView do
   use Pairmotron.Web, :view
+
+  def user_can_edit_group?(user, group) do
+    user.id == group.owner_id or user.is_admin
+  end
 end

--- a/web/views/group_view.ex
+++ b/web/views/group_view.ex
@@ -1,7 +1,13 @@
 defmodule Pairmotron.GroupView do
   use Pairmotron.Web, :view
 
-  def user_can_edit_group?(user, group) do
+  def current_user_can_edit_group?(conn, group) do
+    user = conn.assigns.current_user
     user.id == group.owner_id or user.is_admin
+  end
+
+  def current_user_in_group?(conn, group) do
+    conn.assigns.current_user.groups
+    |> Enum.any?(&(&1.id == group.id))
   end
 end

--- a/web/views/group_view.ex
+++ b/web/views/group_view.ex
@@ -10,4 +10,19 @@ defmodule Pairmotron.GroupView do
     conn.assigns.current_user.groups
     |> Enum.any?(&(&1.id == group.id))
   end
+
+  def current_user_has_requested_membership_to_group?(conn, group) do
+    conn.assigns.current_user.group_membership_requests
+    |> Enum.any?(&(&1.group_id == group.id and &1.initiated_by_user))
+  end
+
+  def current_user_has_been_invited_by_group?(conn, group) do
+    conn.assigns.current_user.group_membership_requests
+    |> Enum.any?(&(&1.group_id == group.id and not &1.initiated_by_user))
+  end
+
+  def current_user_group_membership_request_for_group(conn, group) do
+    conn.assigns.current_user.group_membership_requests
+    |> Enum.find(&(&1.group_id == group.id and not &1.initiated_by_user))
+  end
 end

--- a/web/views/layout_view.ex
+++ b/web/views/layout_view.ex
@@ -1,3 +1,7 @@
 defmodule Pairmotron.LayoutView do
   use Pairmotron.Web, :view
+
+  def logged_in?(conn) do
+    !!conn.assigns[:current_user]
+  end
 end

--- a/web/views/users_group_membership_request_view.ex
+++ b/web/views/users_group_membership_request_view.ex
@@ -1,0 +1,4 @@
+defmodule Pairmotron.UsersGroupMembershipRequestView do
+  use Pairmotron.Web, :view
+
+end


### PR DESCRIPTION
Allow users to request membership in groups and for groups to invite users.

TODO:
- [x] UsersGroupMembershipRequestController
  - [x] :index (user can see all of the outstanding invites they have)
  - [x] :create (user can request membership in a given group)
  - [x] :update (user can accept an invitation that was created by a group owner to join that group)
- [x] GroupInivitationController
  - [x] :index (group owner can see all outstanding invites associated with a group)
  - [x] :new (allow group owner to find a user to invite)
    - [x] Make users dropdown only list users not in the group
  - [x] :create (invites a specific user as the owner of the group)
    - [x] Make errors render to changeset for :new action
  - [x] :update (group owner can accept a membership request that a user created to join their group)
- [x] UI
  - [x] UI for users to request membership in a specific group
  - [x] UI for users to accept membership in a specific group
  - [x] UI for group owners to invite specific users to their group
  - [x] UI for group owners to accept membership requests from a user to their group
  - [x] Link to user's invitations (in profile? dropdown from profile navbar?
  - [x] Link to group's invitations (on group show if current_user is owner of group)

Closes #91 

Subsequent Issues:
- [ ] Allow deletion of group_membership_requests (refusing invitation)