### PR TITLE
Fix 1-pairs not being 'dead' with new users.

### DIFF
--- a/lib/pairmotron/pair_builder.ex
+++ b/lib/pairmotron/pair_builder.ex
@@ -47,9 +47,12 @@ defmodule Pairmotron.PairBuilder do
     dead_users = previously_paired_users_set
       |> MapSet.difference(users_set)
       |> MapSet.to_list
-    dead_users
+    dead_pairs = dead_users
       |> Enum.map(fn dead_user -> Enum.find(pairs, &(dead_user in &1.users)) end)
       |> Enum.filter(&(!is_nil(&1)))
+    pairs
+      |> Enum.filter(&(length(&1.users) == 1))
+      |> Enum.concat(dead_pairs)
       |> Enum.uniq
   end
 

--- a/test/lib/pair_builder_test.exs
+++ b/test/lib/pair_builder_test.exs
@@ -10,6 +10,7 @@ defmodule Pairmotron.PairBuilderTest do
 
   @pair_1 %Pair{id: 1, users: [@user_1, @user_2]}
   @pair_2 %Pair{id: 2, users: [@user_3, @user_4]}
+  @pair_1a %Pair{id: 3, users: [@user_1]}
 
   describe ".determify/2" do
     test "empty pairs and users" do
@@ -63,6 +64,13 @@ defmodule Pairmotron.PairBuilderTest do
       assert determination.dead_pairs |> Enum.sort == []
       assert determination.remaining_pairs |> Enum.sort == [@pair_1]
       assert determination.available_users |> Enum.sort == [@user_3]
+    end
+
+    test "a new user is available and existing 1-pair is no longer valid" do
+      determination = PairBuilder.determify([@pair_1a], [@user_1, @user_3])
+      assert determination.dead_pairs |> Enum.sort == [@pair_1a]
+      assert determination.remaining_pairs |> Enum.sort == []
+      assert determination.available_users |> Enum.sort == [@user_1, @user_3]
     end
   end
 end

--- a/test/lib/pair_maker_test.exs
+++ b/test/lib/pair_maker_test.exs
@@ -31,15 +31,26 @@ defmodule Pairmotron.PairMakerTest do
       assert user.id == userpair.user_id
     end
 
-    test "with 1 existing valid pair does not destroy the pair", %{group: group, user: user} do
-      existing_pair = Pairmotron.TestHelper.create_pair([user], group, 2017, 1)
+    test "with 1 existing valid pair does not destroy the pair", %{user: user} do
+      user2 = insert(:user)
+      group = insert(:group, %{owner: user, users: [user, user2]})
+      existing_pair = Pairmotron.TestHelper.create_pair([user, user2], group, 2017, 1)
       PairMaker.generate_pairs(2017, 1, group.id)
       [pair] = Repo.all(Pair)
       assert existing_pair.id == pair.id
     end
 
-    test "with 1 existing valid pair and 1 existing invalid pair destroys the invalid pair", %{group: group, user: user} do
+    test "with 1 existing 1-pair destroys the pair", %{group: group, user: user} do
       existing_pair = Pairmotron.TestHelper.create_pair([user], group, 2017, 1)
+      PairMaker.generate_pairs(2017, 1, group.id)
+      [pair] = Repo.all(Pair)
+      assert existing_pair.id != pair.id
+    end
+
+    test "with 1 existing valid pair and 1 existing invalid pair destroys the invalid pair", %{user: user} do
+      user2 = insert(:user)
+      group = insert(:group, %{owner: user, users: [user, user2]})
+      existing_pair = Pairmotron.TestHelper.create_pair([user, user2], group, 2017, 1)
       Pairmotron.TestHelper.create_pair([insert(:user)], group, 2017, 1)
       PairMaker.generate_pairs(2017, 1, group.id)
       [pair] = Repo.all(Pair)


### PR DESCRIPTION
1-pairs should always be considered 'dead' once new users are available to pair.
1-pairs are a sort of last resort, and they should always be reconfigured if there are better options.

@mbramson This bug most easily manifested when there was 1 existing pair of 1 user and another user became available, as the test case shows. I think its safe to 💀 any existing 1-pairs when repairifying.