### PR TITLE
Create no groups shared template

### DIFF
--- a/test/controllers/group_pair_controller_test.exs
+++ b/test/controllers/group_pair_controller_test.exs
@@ -4,7 +4,7 @@ defmodule Pairmotron.GroupPairControllerTest do
   import Pairmotron.TestHelper,
     only: [log_in: 2, create_retro: 2, create_pair_and_retro: 2]
 
-  describe "while authenticated" do
+  describe "while authenticated and belonging to a group" do
     setup do
       user = insert(:user)
       group = insert(:group, %{owner: user, users: [user]})
@@ -15,6 +15,11 @@ defmodule Pairmotron.GroupPairControllerTest do
     test "lists the group's name on the page", %{conn: conn, group: group} do
       conn = get(conn, "/groups/#{group.id}/pairs")
       assert html_response(conn, 200) =~ group.name
+    end
+
+    test "displays helpful message when there are no pairs", %{conn: conn, group: group} do
+      conn = get conn, group_pair_path(conn, :show, group, 2000, 1)
+      assert html_response(conn, 200) =~ "No pairs"
     end
 
     test "lists one active user", %{conn: conn, logged_in_user: user, group: group} do

--- a/test/controllers/pair_controller_test.exs
+++ b/test/controllers/pair_controller_test.exs
@@ -4,12 +4,30 @@ defmodule Pairmotron.PairControllerTest do
   import Pairmotron.TestHelper,
     only: [log_in: 2, create_retro: 2, create_pair_and_retro: 2]
 
-  describe "while authenticated" do
+  describe "while authenticated and not belonging to any groups" do
+    setup do
+      user = insert(:user)
+      conn = build_conn() |> log_in(user)
+      {:ok, [conn: conn, logged_in_user: user]}
+    end
+
+    test "displays helpful message when there are no groups", %{conn: conn} do
+      conn = get(conn, "/pairs")
+      assert html_response(conn, 200) =~ "Find a group"
+    end
+  end
+
+  describe "while authenticated and belonging to a group" do
     setup do
       user = insert(:user)
       group = insert(:group, %{owner: user, users: [user]})
       conn = build_conn() |> log_in(user)
       {:ok, [conn: conn, logged_in_user: user, group: group]}
+    end
+
+    test "displays helpful message when there are no pairs", %{conn: conn} do
+      conn = get conn, pair_path(conn, :show, 2000, 1)
+      assert html_response(conn, 200) =~ "No pairs"
     end
 
     test "displays link to retro :create for a pair and current user with no retrospective",

--- a/test/controllers/profile_controller_test.exs
+++ b/test/controllers/profile_controller_test.exs
@@ -34,6 +34,11 @@ defmodule Pairmotron.ProfileControllerTest do
       assert html_response(conn, 200) =~ group_path(conn, :show, group2)
     end
 
+    test "displays the no groups actions when the user has no groups", %{conn: conn} do
+      conn = get conn, profile_path(conn, :show)
+      assert html_response(conn, 200) =~ "Find a group"
+    end
+
     test "links to group edit if current user is owner", %{conn: conn, logged_in_user: user} do
       group1 = insert(:group, %{owner: user, users: [user]})
       conn = get conn, profile_path(conn, :show)

--- a/web/templates/group_pair/index.html.eex
+++ b/web/templates/group_pair/index.html.eex
@@ -6,6 +6,9 @@
       <%= for pair <- @pairs do %>
         <%= render Pairmotron.SharedView, "pair.html", pair: pair, conn: @conn %>
       <% end %>
+      <%= if Enum.empty?(@pairs) do %>
+        <p>No pairs available</p>
+      <% end %>
     </ul>
   </div>
 </div>

--- a/web/templates/pair/index.html.eex
+++ b/web/templates/pair/index.html.eex
@@ -8,6 +8,12 @@
         <%= for pair <- pairs do %>
           <%= render Pairmotron.SharedView, "pair.html", pair: pair, conn: @conn %>
         <% end %>
+        <%= if Enum.empty?(pairs) do %>
+          <p>No pairs available</p>
+        <% end %>
+      <% end %>
+      <%= if Enum.empty?(@groups_and_pairs) do %>
+        <%= render Pairmotron.SharedView, "no_group.html", conn: @conn %>
       <% end %>
     </ul>
   </div>

--- a/web/templates/profile/show.html.eex
+++ b/web/templates/profile/show.html.eex
@@ -45,6 +45,9 @@
             </td>
           </tr>
         <% end %>
+        <%= if Enum.empty?(@user.groups) do %>
+          <%= render Pairmotron.SharedView, "no_group.html", conn: @conn %>
+        <% end %>
       </tbody>
     </table>
   </div>

--- a/web/templates/project/no_groups.html.eex
+++ b/web/templates/project/no_groups.html.eex
@@ -1,14 +1,1 @@
-<p>
-  <strong>
-    Projects have to be associated with groups. It looks like you aren't in a group. Find a group to join or create your own!
-  </strong>
-</p>
-
-<p>
-  <a href=<%= group_path(@conn, :index) %>>
-    <button class="btn btn-primary">Find Group</button>
-  </a>
-  <a href=<%= group_path(@conn, :new) %>>
-    <button class="btn btn-primary">Create Group</button>
-  </a>
-</p>
+<%= render Pairmotron.SharedView, "no_group.html", conn: @conn %>

--- a/web/templates/shared/no_group.html.eex
+++ b/web/templates/shared/no_group.html.eex
@@ -1,0 +1,14 @@
+<p>
+  <strong>
+    It looks like you aren't in a group. Find a group to join or create your own!
+  </strong>
+</p>
+
+<p>
+  <a href=<%= group_path(@conn, :index) %>>
+    <button class="btn btn-primary">Find Group</button>
+  </a>
+  <a href=<%= group_path(@conn, :new) %>>
+    <button class="btn btn-primary">Create Group</button>
+  </a>
+</p>


### PR DESCRIPTION
@mbramson I hijacked the project no_group template as a shared template, but I wanted to get your feedback on this before I do any more. I'll call out a couple things in comments here in a moment.

As Anna, a user with no current groups:
She has no groups on /pair

![screen shot 2017-02-22 at 12 13 22 pm](https://cloud.githubusercontent.com/assets/4420576/23223256/891aa50a-f8f8-11e6-8335-847bd939e68e.png)

She has no groups in /profile

![screen shot 2017-02-22 at 12 13 30 pm](https://cloud.githubusercontent.com/assets/4420576/23223254/8917edec-f8f8-11e6-945e-c5802272af0e.png)

She has no groups in /projects

![screen shot 2017-02-22 at 12 13 40 pm](https://cloud.githubusercontent.com/assets/4420576/23223255/89182d20-f8f8-11e6-8310-d511762d14ef.png)


As Eric, a user in a couple of groups (but turned inactive for sake of showing this):
His /pairs shows his groups are empty. This is what users will see if they look in the past or future

![screen shot 2017-02-22 at 12 14 24 pm](https://cloud.githubusercontent.com/assets/4420576/23223252/8915a744-f8f8-11e6-8cbc-1acf13aa769b.png)

His groups show no pairs as well

![screen shot 2017-02-22 at 12 14 38 pm](https://cloud.githubusercontent.com/assets/4420576/23223253/8917e982-f8f8-11e6-99a6-9c7d7982aac7.png)




