### PR TITLE
Fix not being able to change name without also inputting password

### DIFF
--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -32,14 +32,17 @@ defmodule Pairmotron.User do
     |> common_changeset
   end
 
-  @required_profile_params ~w(name email password password_confirmation)
-  @optional_profile_params ~w(active)
+  @required_registration_params ~w(name email password password_confirmation)
+  @optional_registration_params ~w(active)
 
   def registration_changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, @required_profile_params, @optional_profile_params)
+    |> cast(params, @required_registration_params, @optional_registration_params)
     |> common_changeset
   end
+
+  @required_profile_params ~w(name email)
+  @optional_profile_params ~w(active password password_confirmation)
 
   def profile_changeset(struct, params \\ %{}) do
     struct


### PR DESCRIPTION
Logged in users can now change their name, email, or active without also inputting their password.