### PR TITLE
Extract login setup for controller tests

### DIFF
--- a/test/controllers/group_controller_test.exs
+++ b/test/controllers/group_controller_test.exs
@@ -2,7 +2,6 @@ defmodule Pairmotron.GroupControllerTest do
   use Pairmotron.ConnCase
 
   alias Pairmotron.Group
-  import Pairmotron.TestHelper, only: [log_in: 2]
 
   @valid_attrs %{name: "some content"}
   @invalid_attrs %{}
@@ -12,21 +11,31 @@ defmodule Pairmotron.GroupControllerTest do
     assert redirected_to(conn) == session_path(conn, :new)
   end
 
-  describe "while authenticated" do
+  describe "using :index while authenticated" do
     setup do
-      user = insert(:user)
-      conn = build_conn() |> log_in(user)
-      {:ok, [conn: conn, logged_in_user: user]}
+      login_user()
     end
 
     test "lists all entries on index", %{conn: conn} do
       conn = get conn, group_path(conn, :index)
       assert html_response(conn, 200) =~ "Listing groups"
     end
+  end
+
+  describe "using :new while authenticated" do
+    setup do
+      login_user()
+    end
 
     test "renders form for new resources", %{conn: conn} do
       conn = get conn, group_path(conn, :new)
       assert html_response(conn, 200) =~ "New group"
+    end
+  end
+
+  describe "using :create while authenticated" do
+    setup do
+      login_user()
     end
 
     test "creates resource and redirects when data is valid", %{conn: conn, logged_in_user: user} do
@@ -47,6 +56,12 @@ defmodule Pairmotron.GroupControllerTest do
     test "does not create resource and renders errors when data is invalid", %{conn: conn} do
       conn = post conn, group_path(conn, :create), group: @invalid_attrs
       assert html_response(conn, 200) =~ "New group"
+    end
+  end
+
+  describe "using :show while authenticated" do
+    setup do
+      login_user()
     end
 
     test "shows chosen resource", %{conn: conn} do
@@ -115,6 +130,12 @@ defmodule Pairmotron.GroupControllerTest do
         get conn, group_path(conn, :show, -1)
       end
     end
+  end
+
+  describe "using :edit while authenticated" do
+    setup do
+      login_user()
+    end
 
     test "renders form for editing chosen resource", %{conn: conn, logged_in_user: user} do
       group = insert(:group, owner: user)
@@ -126,6 +147,12 @@ defmodule Pairmotron.GroupControllerTest do
       group = insert(:group)
       conn = get conn, group_path(conn, :edit, group)
       assert redirected_to(conn) == group_path(conn, :index)
+    end
+  end
+
+  describe "using :update while authenticated" do
+    setup do
+      login_user()
     end
 
     test "updates chosen resource and redirects when data is valid", %{conn: conn, logged_in_user: user} do
@@ -147,6 +174,12 @@ defmodule Pairmotron.GroupControllerTest do
       conn = put conn, group_path(conn, :update, group), group: @invalid_attrs
       assert html_response(conn, 200) =~ "Edit group"
     end
+  end
+
+  describe "using :delete while authenticated" do
+    setup do
+      login_user()
+    end
 
     test "deletes chosen resource", %{conn: conn, logged_in_user: user} do
       group = insert(:group, owner: user)
@@ -165,9 +198,7 @@ defmodule Pairmotron.GroupControllerTest do
 
   describe "as admin" do
     setup do
-      user = insert(:user_admin)
-      conn = build_conn() |> log_in(user)
-      {:ok, [conn: conn, logged_in_user: user]}
+      login_admin_user()
     end
 
     test "admin may edit a group not owned by admin", %{conn: conn, logged_in_user: user} do

--- a/test/controllers/group_invitation_controller_test.exs
+++ b/test/controllers/group_invitation_controller_test.exs
@@ -63,9 +63,7 @@ defmodule Pairmotron.GroupInvitationControllerTest do
 
   describe "using :new while authenticated" do
     setup do
-      user = insert(:user)
-      conn = build_conn() |> log_in(user)
-      {:ok, [conn: conn, logged_in_user: user]}
+      login_user()
     end
 
     test "renders invitation form if user is owner of group", %{conn: conn, logged_in_user: user} do
@@ -104,9 +102,7 @@ defmodule Pairmotron.GroupInvitationControllerTest do
 
   describe "using :create while authenticated" do
     setup do
-      user = insert(:user)
-      conn = build_conn() |> log_in(user)
-      {:ok, [conn: conn, logged_in_user: user]}
+      login_user()
     end
 
     test "can create a group_membership_request if current_user is owner of group", %{conn: conn, logged_in_user: user} do
@@ -186,9 +182,7 @@ defmodule Pairmotron.GroupInvitationControllerTest do
 
   describe "using :update while authenticated" do
     setup do
-      user = insert(:user)
-      conn = build_conn() |> log_in(user)
-      {:ok, [conn: conn, logged_in_user: user]}
+      login_user()
     end
 
     test "creates a group and deletes group_invite if group_invite exists and created by user", %{conn: conn, logged_in_user: user} do

--- a/test/controllers/profile_controller_test.exs
+++ b/test/controllers/profile_controller_test.exs
@@ -2,7 +2,6 @@ defmodule Pairmotron.ProfileControllerTest do
   use Pairmotron.ConnCase
 
   alias Pairmotron.User
-  import Pairmotron.TestHelper, only: [log_in: 2]
 
   @valid_attrs %{email: "email", name: "name", password: "password", password_confirmation: "password"}
 
@@ -11,11 +10,9 @@ defmodule Pairmotron.ProfileControllerTest do
     assert redirected_to(conn) == session_path(conn, :new)
   end
 
-  describe "while authenticated" do
+  describe "using :show while authenticated" do
     setup do
-      user = insert(:user)
-      conn = build_conn() |> log_in(user)
-      {:ok, [conn: conn, logged_in_user: user]}
+      login_user()
     end
 
     test "shows the current user", %{conn: conn, logged_in_user: user} do
@@ -51,10 +48,22 @@ defmodule Pairmotron.ProfileControllerTest do
       conn = get conn, profile_path(conn, :show)
       refute html_response(conn, 200) =~ group_path(conn, :edit, group1)
     end
+  end
+
+  describe "using :edit while authenticated" do
+    setup do
+      login_user()
+    end
 
     test "renders form for editing the current user", %{conn: conn} do
       conn = get conn, profile_path(conn, :edit)
       assert html_response(conn, 200) =~ "Edit Profile"
+    end
+  end
+
+  describe "using :update while authenticated" do
+    setup do
+      login_user()
     end
 
     test "updates current user", %{conn: conn, logged_in_user: user} do

--- a/test/controllers/users_group_membership_request_controller_test.exs
+++ b/test/controllers/users_group_membership_request_controller_test.exs
@@ -3,8 +3,6 @@ defmodule Pairmotron.UsersGroupMembershipRequestControllerTest do
 
   alias Pairmotron.{GroupMembershipRequest, UserGroup}
 
-  import Pairmotron.TestHelper, only: [log_in: 2]
-
   test "redirects to sign-in when not logged in", %{conn: conn} do
     conn = get conn, users_group_membership_request_path(conn, :index)
     assert redirected_to(conn) == session_path(conn, :new)
@@ -12,9 +10,7 @@ defmodule Pairmotron.UsersGroupMembershipRequestControllerTest do
 
   describe "using :index while authenticated" do
     setup do
-      user = insert(:user)
-      conn = build_conn() |> log_in(user)
-      {:ok, [conn: conn, logged_in_user: user]}
+      login_user()
     end
 
     test "states that there are no active invitations when there are not", %{conn: conn} do
@@ -53,9 +49,7 @@ defmodule Pairmotron.UsersGroupMembershipRequestControllerTest do
 
   describe "using :create while authenticated" do
     setup do
-      user = insert(:user)
-      conn = build_conn() |> log_in(user)
-      {:ok, [conn: conn, logged_in_user: user]}
+      login_user()
     end
 
     test "can create a group_membership_request", %{conn: conn, logged_in_user: user} do
@@ -113,9 +107,7 @@ defmodule Pairmotron.UsersGroupMembershipRequestControllerTest do
 
   describe "using :update while authenticated" do
     setup do
-      user = insert(:user)
-      conn = build_conn() |> log_in(user)
-      {:ok, [conn: conn, logged_in_user: user]}
+      login_user()
     end
 
     test "creates a group and deletes group_invite if group_invite exists and created by group", %{conn: conn, logged_in_user: user} do

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -27,6 +27,7 @@ defmodule Pairmotron.ConnCase do
 
       import Pairmotron.Router.Helpers
       import Pairmotron.Factory
+      import Pairmotron.LoginHelper
 
       # The default endpoint for testing
       @endpoint Pairmotron.Endpoint

--- a/test/support/login_helper.ex
+++ b/test/support/login_helper.ex
@@ -1,0 +1,11 @@
+defmodule Pairmotron.LoginHelper do
+  import Pairmotron.Factory
+  import Pairmotron.TestHelper, only: [log_in: 2]
+  import Phoenix.ConnTest
+
+  def login_user() do
+    user = insert(:user)
+    conn = build_conn() |> log_in(user)
+    {:ok, [conn: conn, logged_in_user: user]}
+  end
+end

--- a/test/support/login_helper.ex
+++ b/test/support/login_helper.ex
@@ -8,4 +8,10 @@ defmodule Pairmotron.LoginHelper do
     conn = build_conn() |> log_in(user)
     {:ok, [conn: conn, logged_in_user: user]}
   end
+
+  def login_admin_user() do
+    user = insert(:user_admin)
+    conn = build_conn() |> log_in(user)
+    {:ok, [conn: conn, logged_in_user: user]}
+  end
 end


### PR DESCRIPTION
There was a lot of duplicate code in the controller tests building the connection, the user, and logging in the user.

This PR extracts that to `Pairmotron.LoginHelper` which is automatically imported via `use Pairmotron.ConnCase`.

Controller Tests have also had their actions separated out by describes to allow for shortened test descriptions and easier future test implementation.