### PR TITLE
Remove login link at bottom of register form

### DIFF
--- a/web/templates/registration/new.html.eex
+++ b/web/templates/registration/new.html.eex
@@ -31,7 +31,6 @@
   </div>
 
   <div class="form-group">
-    <%= link("Login", to: session_path(@conn, :new), class: "btn btn-success") %>
     <%= submit "Register", class: "btn btn-primary pull-right" %>
   </div>
 <% end %>


### PR DESCRIPTION
Small UX change to the register form.

## Why

It's easy to confuse at a glance for the form submit for the register form. When it is clicked it drops all of the entries and the user needs to restart. It's in the nav bar so I don't see why it needs to also be at the bottom of the register form.

## How

Remove it.