### PR TITLE
Make registration use User.registration_changeset

### DIFF
--- a/web/controllers/registration_controller.ex
+++ b/web/controllers/registration_controller.ex
@@ -10,7 +10,7 @@ defmodule Pairmotron.RegistrationController do
   end
 
   def create(conn, %{"user" => user_params}) do
-    changeset = User.profile_changeset(%User{}, user_params)
+    changeset = User.registration_changeset(%User{}, user_params)
 
     case Repo.insert(changeset) do
       {:ok, user} ->


### PR DESCRIPTION
registration was erroneously using User.profile_changeset, which as of a
recent fix allowed users to hit the non-null password db constraint when
registering rather than seeing a helpful error message around the
password field stating that it can't be blank

closes #106 