### PR TITLE
Fix updating retros with new users or pairs

### DIFF
--- a/test/controllers/pair_retro_controller_test.exs
+++ b/test/controllers/pair_retro_controller_test.exs
@@ -3,7 +3,7 @@ defmodule Pairmotron.PairRetroControllerTest do
 
   alias Pairmotron.PairRetro
   import Pairmotron.TestHelper,
-    only: [log_in: 2, create_pair: 4, create_retro: 2, create_pair_and_retro: 2]
+    only: [create_retro: 2, create_pair_and_retro: 2]
 
   @valid_attrs %{subject: "some content", reflection: "some content", pair_date: Timex.today}
   @invalid_attrs %{}
@@ -16,17 +16,14 @@ defmodule Pairmotron.PairRetroControllerTest do
   defp create_user_and_pair_and_retro() do
     user = insert(:user)
     group = insert(:group, %{owner: user})
-    pair = Pairmotron.TestHelper.create_pair([user], group)
-    retro = create_retro(user, pair)
+    pair = insert(:pair, %{group: group, users: [user]})
+    retro = insert(:retro, user: user, pair: pair)
     {user, pair, retro}
   end
 
-  describe "while authenticated" do
+  describe "using :index while authenticated" do
     setup do
-      user = insert(:user)
-      group = insert(:group, %{owner: user})
-      conn = build_conn() |> log_in(user)
-      {:ok, [conn: conn, logged_in_user: user, group: group]}
+      login_user()
     end
 
     test "lists all entries on index", %{conn: conn} do
@@ -34,7 +31,8 @@ defmodule Pairmotron.PairRetroControllerTest do
       assert html_response(conn, 200) =~ "Listing your retrospectives"
     end
 
-    test "lists the current user's retrospectives", %{conn: conn, logged_in_user: user, group: group} do
+    test "lists the current user's retrospectives", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{owner: user, users: [user]})
       {_pair, retro} = create_pair_and_retro(user, group)
       conn = get conn, pair_retro_path(conn, :index)
       assert html_response(conn, 200) =~ Ecto.Date.to_string(retro.pair_date)
@@ -45,15 +43,29 @@ defmodule Pairmotron.PairRetroControllerTest do
       conn = get conn, pair_retro_path(conn, :index)
       refute html_response(conn, 200) =~ Ecto.Date.to_string(retro.pair_date)
     end
+  end
 
-    test "renders form for new resources", %{conn: conn, logged_in_user: user, group: group} do
-      pair = Pairmotron.TestHelper.create_pair([user], group)
+  describe "using :new while authenticated" do
+    setup do
+      login_user()
+    end
+
+    test "renders form for new resources", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{owner: user, users: [user]})
+      pair = insert(:pair, %{group: group, users: [user]})
       conn = get conn, pair_retro_path(conn, :new, pair.id)
       assert html_response(conn, 200) =~ "New retrospective"
     end
+  end
 
-    test "creates retro and redirects when data is valid and user is logged in", %{conn: conn, logged_in_user: user, group: group} do
-      pair = Pairmotron.TestHelper.create_pair([user], group)
+  describe "using :create while authenticated" do
+    setup do
+      login_user()
+    end
+
+    test "creates retro and redirects when data is valid and user is logged in", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{owner: user, users: [user]})
+      pair = insert(:pair, %{group: group, users: [user]})
       attrs = Map.merge(@valid_attrs, %{pair_id: Integer.to_string(pair.id),
                                         user_id: Integer.to_string(user.id)})
       conn = post conn, pair_retro_path(conn, :create), pair_retro: attrs
@@ -61,8 +73,9 @@ defmodule Pairmotron.PairRetroControllerTest do
       assert Repo.get_by(PairRetro, attrs)
     end
 
-    test "cannot create retro with a pair_date before the pair's week", %{conn: conn, logged_in_user: user, group: group} do
-      pair = Pairmotron.TestHelper.create_pair([user], group,  2016, 1)
+    test "cannot create retro with a pair_date before the pair's week", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{owner: user, users: [user]})
+      pair = insert(:pair, %{group: group, users: [user], year: 2016, week: 1})
       attrs = Map.merge(@valid_attrs, %{pair_date: ~D(1999-10-20),
                                         pair_id: Integer.to_string(pair.id),
                                         user_id: Integer.to_string(user.id)})
@@ -71,9 +84,12 @@ defmodule Pairmotron.PairRetroControllerTest do
       assert html_response(conn, 200) =~ "cannot be before the week of the pair"
     end
 
-    test "cannot create retro without a user_id parameter", %{conn: conn, logged_in_user: user, group: group} do
-      pair = Pairmotron.TestHelper.create_pair([user], group)
+    test "cannot create retro without a user_id parameter", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{owner: user, users: [user]})
+      pair = insert(:pair, %{group: group, users: [user]})
+
       attrs = Map.merge(@valid_attrs, %{pair_id: Integer.to_string(pair.id)})
+
       conn = post conn, pair_retro_path(conn, :create), pair_retro: attrs
       assert html_response(conn, 200) =~ "New retrospective"
       assert html_response(conn, 200) =~ "something went wrong"
@@ -82,8 +98,8 @@ defmodule Pairmotron.PairRetroControllerTest do
 
     test "cannot create retro when the retros user is not the logged in user", %{conn: conn} do
       user = insert(:user)
-      group = insert(:group, %{owner: user})
-      pair = Pairmotron.TestHelper.create_pair([user], group)
+      group = insert(:group, %{owner: user, users: [user]})
+      pair = insert(:pair, %{group: group, users: [user]})
       attrs = Map.merge(@valid_attrs, %{pair_id: Integer.to_string(pair.id),
                                         user_id: Integer.to_string(user.id)})
       conn = post conn, pair_retro_path(conn, :create), pair_retro: attrs
@@ -95,8 +111,15 @@ defmodule Pairmotron.PairRetroControllerTest do
       conn = post conn, pair_retro_path(conn, :create), pair_retro: @invalid_attrs
       assert html_response(conn, 200) =~ "New retrospective"
     end
+  end
 
-    test "can show the logged in user's retrospective", %{conn: conn, logged_in_user: user, group: group} do
+  describe "using :show while authenticated" do
+    setup do
+      login_user()
+    end
+
+    test "can show the logged in user's retrospective", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{owner: user, users: [user]})
       {_pair, retro} = create_pair_and_retro(user, group)
       conn = get conn, pair_retro_path(conn, :show, retro)
       assert html_response(conn, 200) =~ "Show retrospective"
@@ -113,9 +136,16 @@ defmodule Pairmotron.PairRetroControllerTest do
       conn = get conn, pair_retro_path(conn, :show, -1)
       assert html_response(conn, 404) =~ "Page not found"
     end
+  end
 
-    test "renders form for editing logged in user's own resource", %{conn: conn, logged_in_user: user, group: group} do
-      pair = Pairmotron.TestHelper.create_pair([user], group)
+  describe "using :edit while authenticated" do
+    setup do
+      login_user()
+    end
+
+    test "renders form for editing logged in user's own resource", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{owner: user, users: [user]})
+      pair = insert(:pair, %{group: group, users: [user]})
       retro = create_retro(user, pair)
       conn = get conn, pair_retro_path(conn, :edit, retro)
       assert html_response(conn, 200) =~ "Edit retrospective"
@@ -127,46 +157,93 @@ defmodule Pairmotron.PairRetroControllerTest do
       assert redirected_to(conn) == pair_retro_path(conn, :index)
       assert %{"error" => _} = conn.private.phoenix_flash
     end
+  end
 
-    test "updates logged in users' retro and redirects when data is valid", %{conn: conn, logged_in_user: user, group: group} do
-      pair = Pairmotron.TestHelper.create_pair([user], group)
-      attrs = Map.merge(@valid_attrs, %{pair_id: pair.id, user_id: user.id})
-      pair_retro = Repo.insert! %PairRetro{user_id: user.id}
+  describe "using :update while authenticated" do
+    setup do
+      login_user()
+    end
+
+    test "updates logged in users' retro and redirects when data is valid", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{owner: user, users: [user]})
+      pair = insert(:pair, %{group: group, users: [user]})
+      pair_retro = insert(:retro, %{user: user, pair: pair})
+
+      attrs = Map.merge(@valid_attrs, %{subject: "different subject", reflection: "learned so much more"})
+
       conn = put conn, pair_retro_path(conn, :update, pair_retro), pair_retro: attrs
       assert redirected_to(conn) == pair_retro_path(conn, :show, pair_retro)
       assert Repo.get_by(PairRetro, attrs)
     end
 
-    test "does not update retro with a pair_date before the pair's week", %{conn: conn, logged_in_user: user, group: group} do
-      pair = create_pair([user], group, 2016, 1)
-      attrs = Map.merge(@valid_attrs, %{pair_date: ~D(1999-10-20),
-                                        pair_id: pair.id,
-                                        user_id: user.id})
-      pair_retro = Repo.insert! %PairRetro{user_id: user.id}
+    test "does not update retro with a pair_date before the pair's week", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{owner: user, users: [user]})
+      pair = insert(:pair, %{group: group, users: [user], year: 2016, week: 1})
+      pair_retro = insert(:retro, %{user: user, pair: pair})
+
+      new_pair_date = {1999, 10, 20} |> Ecto.Date.from_erl
+      attrs = Map.merge(@valid_attrs, %{pair_date: new_pair_date})
+
       conn = put conn, pair_retro_path(conn, :update, pair_retro), pair_retro: attrs
       assert html_response(conn, 200) =~ "Edit retrospective"
       assert html_response(conn, 200) =~ "cannot be before the week of the pair"
     end
 
-    test "does not update retro of user who is not the logged in user", %{conn: conn} do
-      user = insert(:user)
-      group = insert(:group, %{owner: user})
-      pair = Pairmotron.TestHelper.create_pair([user], group)
+    test "does not update retro of user who is not the logged in user", %{conn: conn, logged_in_user: user} do
+      other_user = insert(:user)
+      group = insert(:group, %{owner: user, users: [user]})
+      pair = insert(:pair, %{group: group, users: [other_user]})
+      pair_retro = insert(:retro, %{pair: pair, user: other_user})
+
       attrs = Map.merge(@valid_attrs, %{pair_id: pair.id, user_id: user.id})
-      pair_retro = Repo.insert! %PairRetro{}
+
       conn = put conn, pair_retro_path(conn, :update, pair_retro), pair_retro: attrs
       assert redirected_to(conn) == pair_retro_path(conn, :index)
       assert %{"error" => _} = conn.private.phoenix_flash
       refute Repo.get_by(PairRetro, attrs)
     end
 
+    test "cannot change retro to a different user", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{owner: user, users: [user]})
+      pair = insert(:pair, %{group: group, users: [user]})
+      other_user = insert(:user)
+      pair_retro = insert(:retro, %{pair: pair, user: user})
+
+      attrs = Map.merge(@valid_attrs, %{pair_id: pair.id, user_id: other_user.id})
+
+      put conn, pair_retro_path(conn, :update, pair_retro), pair_retro: attrs
+      refute Repo.get_by(PairRetro, attrs)
+    end
+
+    test "cannot change retro to a different pair", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{owner: user, users: [user]})
+      pair = insert(:pair, %{group: group, users: [user]})
+      other_pair = insert(:pair, %{group: group})
+      pair_retro = insert(:retro, %{pair: pair, user: user})
+
+      attrs = Map.merge(@valid_attrs, %{pair_id: other_pair.id, user_id: user.id})
+
+      put conn, pair_retro_path(conn, :update, pair_retro), pair_retro: attrs
+      refute Repo.get_by(PairRetro, attrs)
+    end
+
     test "does not update chosen resource and renders errors when data is invalid", %{conn: conn, logged_in_user: user} do
-      pair_retro = Repo.insert! %PairRetro{user_id: user.id}
+      group = insert(:group, %{owner: user, users: [user]})
+      pair = insert(:pair, %{group: group, users: [user]})
+      pair_retro = Repo.insert! %PairRetro{user_id: user.id, pair_id: pair.id}
+
       conn = put conn, pair_retro_path(conn, :update, pair_retro), pair_retro: @invalid_attrs
       assert html_response(conn, 200) =~ "Edit retrospective"
     end
+  end
 
-    test "can delete the logged in users' retro", %{conn: conn, logged_in_user: user, group: group} do
+  describe "using :delete while authenticated" do
+    setup do
+      login_user()
+    end
+
+    test "can delete the logged in users' retro", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{owner: user, users: [user]})
       {_pair, retro} = create_pair_and_retro(user, group)
       conn = delete conn, pair_retro_path(conn, :delete, retro)
       assert redirected_to(conn) == pair_retro_path(conn, :index)
@@ -184,17 +261,17 @@ defmodule Pairmotron.PairRetroControllerTest do
 
   describe "as admin" do
     setup do
-      user = insert(:user_admin)
-      conn = build_conn() |> log_in(user)
-      {:ok, [conn: conn, logged_in_user: user]}
+      login_admin_user()
     end
 
     test "creates other user's retro and redirects", %{conn: conn} do
       user = insert(:user)
       group = insert(:group, %{owner: user})
-      pair = Pairmotron.TestHelper.create_pair([user], group)
+      pair = insert(:pair, %{group: group, users: [user]})
+
       attrs = Map.merge(@valid_attrs, %{pair_id: Integer.to_string(pair.id),
                                         user_id: Integer.to_string(user.id)})
+
       conn = post conn, pair_retro_path(conn, :create), pair_retro: attrs
       assert redirected_to(conn) == pair_retro_path(conn, :index)
       assert Repo.get_by(PairRetro, attrs)
@@ -209,9 +286,11 @@ defmodule Pairmotron.PairRetroControllerTest do
     test "updates other user's retrospective and redirects when data is valid", %{conn: conn} do
       user = insert(:user)
       group = insert(:group, %{owner: user})
-      pair = Pairmotron.TestHelper.create_pair([user], group)
+      pair = insert(:pair, %{group: group, users: [user]})
+      pair_retro = Repo.insert! %PairRetro{user_id: user.id, pair_id: pair.id}
+
       attrs = Map.merge(@valid_attrs, %{pair_id: pair.id, user_id: user.id})
-      pair_retro = Repo.insert! %PairRetro{user_id: user.id}
+
       conn = put conn, pair_retro_path(conn, :update, pair_retro), pair_retro: attrs
       assert redirected_to(conn) == pair_retro_path(conn, :show, pair_retro)
       assert Repo.get_by(PairRetro, attrs)

--- a/test/controllers/pair_retro_controller_test.exs
+++ b/test/controllers/pair_retro_controller_test.exs
@@ -2,8 +2,7 @@ defmodule Pairmotron.PairRetroControllerTest do
   use Pairmotron.ConnCase
 
   alias Pairmotron.PairRetro
-  import Pairmotron.TestHelper,
-    only: [create_retro: 2, create_pair_and_retro: 2]
+  import Pairmotron.TestHelper, only: [create_pair_and_retro: 2]
 
   @valid_attrs %{subject: "some content", reflection: "some content", pair_date: Timex.today}
   @invalid_attrs %{}
@@ -200,7 +199,7 @@ defmodule Pairmotron.PairRetroControllerTest do
     test "renders form for editing logged in user's own resource", %{conn: conn, logged_in_user: user} do
       group = insert(:group, %{owner: user, users: [user]})
       pair = insert(:pair, %{group: group, users: [user]})
-      retro = create_retro(user, pair)
+      retro = insert(:retro, %{user: user, pair: pair})
       conn = get conn, pair_retro_path(conn, :edit, retro)
       assert html_response(conn, 200) =~ "Edit retrospective"
     end

--- a/test/controllers/pair_retro_controller_test.exs
+++ b/test/controllers/pair_retro_controller_test.exs
@@ -63,7 +63,7 @@ defmodule Pairmotron.PairRetroControllerTest do
       login_user()
     end
 
-    test "creates retro and redirects when data is valid and user is logged in", %{conn: conn, logged_in_user: user} do
+    test "creates retro and redirects when data is valid", %{conn: conn, logged_in_user: user} do
       group = insert(:group, %{owner: user, users: [user]})
       pair = insert(:pair, %{group: group, users: [user]})
 
@@ -75,7 +75,7 @@ defmodule Pairmotron.PairRetroControllerTest do
       assert Repo.get_by(PairRetro, attrs)
     end
 
-    test "cannot create retro with a pair_date before the pair's week", %{conn: conn, logged_in_user: user} do
+    test "fails with a pair_date before the pair's week", %{conn: conn, logged_in_user: user} do
       group = insert(:group, %{owner: user, users: [user]})
       pair = insert(:pair, %{group: group, users: [user], year: 2016, week: 1})
 
@@ -88,7 +88,7 @@ defmodule Pairmotron.PairRetroControllerTest do
       assert html_response(conn, 200) =~ "cannot be before the week of the pair"
     end
 
-    test "cannot create retro without a pair_date parameter", %{conn: conn, logged_in_user: user} do
+    test "fails without a pair_date parameter", %{conn: conn, logged_in_user: user} do
       group = insert(:group, %{owner: user, users: [user]})
       pair = insert(:pair, %{group: group, users: [user]})
 
@@ -143,14 +143,14 @@ defmodule Pairmotron.PairRetroControllerTest do
       login_user()
     end
 
-    test "can show the logged in user's retrospective", %{conn: conn, logged_in_user: user} do
+    test "displays a logged in user's retrospective", %{conn: conn, logged_in_user: user} do
       group = insert(:group, %{owner: user, users: [user]})
       {_pair, retro} = create_pair_and_retro(user, group)
       conn = get conn, pair_retro_path(conn, :show, retro)
       assert html_response(conn, 200) =~ "Show retrospective"
     end
 
-    test "cannot show other user's retrospective", %{conn: conn} do
+    test "does not display a different user's retrospective", %{conn: conn} do
       {_user, _pair, retro} = create_user_and_pair_and_retro()
       conn = get conn, pair_retro_path(conn, :show, retro)
       assert redirected_to(conn) == pair_retro_path(conn, :index)
@@ -201,7 +201,7 @@ defmodule Pairmotron.PairRetroControllerTest do
       assert Repo.get_by(PairRetro, attrs)
     end
 
-    test "does not update retro with a pair_date before the pair's week", %{conn: conn, logged_in_user: user} do
+    test "fails with a pair_date before the pair's week", %{conn: conn, logged_in_user: user} do
       group = insert(:group, %{owner: user, users: [user]})
       pair = insert(:pair, %{group: group, users: [user], year: 2016, week: 1})
       pair_retro = insert(:retro, %{user: user, pair: pair})
@@ -214,7 +214,7 @@ defmodule Pairmotron.PairRetroControllerTest do
       assert html_response(conn, 200) =~ "cannot be before the week of the pair"
     end
 
-    test "does not update retro of user who is not the logged in user", %{conn: conn, logged_in_user: user} do
+    test "fails to update a different user's retro", %{conn: conn, logged_in_user: user} do
       other_user = insert(:user)
       group = insert(:group, %{owner: user, users: [user]})
       pair = insert(:pair, %{group: group, users: [other_user]})
@@ -228,7 +228,7 @@ defmodule Pairmotron.PairRetroControllerTest do
       refute Repo.get_by(PairRetro, attrs)
     end
 
-    test "cannot change retro to a different user", %{conn: conn, logged_in_user: user} do
+    test "fails to change retro to a different user", %{conn: conn, logged_in_user: user} do
       group = insert(:group, %{owner: user, users: [user]})
       pair = insert(:pair, %{group: group, users: [user]})
       other_user = insert(:user)
@@ -240,7 +240,7 @@ defmodule Pairmotron.PairRetroControllerTest do
       refute Repo.get_by(PairRetro, attrs)
     end
 
-    test "cannot change retro to a different pair", %{conn: conn, logged_in_user: user} do
+    test "fails to change retro to a different pair", %{conn: conn, logged_in_user: user} do
       group = insert(:group, %{owner: user, users: [user]})
       pair = insert(:pair, %{group: group, users: [user]})
       other_pair = insert(:pair, %{group: group})
@@ -267,7 +267,7 @@ defmodule Pairmotron.PairRetroControllerTest do
       login_user()
     end
 
-    test "can delete the logged in users' retro", %{conn: conn, logged_in_user: user} do
+    test "deletes the logged in users' retro", %{conn: conn, logged_in_user: user} do
       group = insert(:group, %{owner: user, users: [user]})
       {_pair, retro} = create_pair_and_retro(user, group)
 
@@ -276,7 +276,7 @@ defmodule Pairmotron.PairRetroControllerTest do
       refute Repo.get(PairRetro, retro.id)
     end
 
-    test "can not delete retro of a user that is not logged in", %{conn: conn} do
+    test "fails to delete retro of a user that is not logged in", %{conn: conn} do
       {_user, _pair, retro} = create_user_and_pair_and_retro()
 
       conn = delete conn, pair_retro_path(conn, :delete, retro)

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -53,4 +53,21 @@ defmodule Pairmotron.Factory do
   def group_membership_request_factory do
     %Pairmotron.GroupMembershipRequest{}
   end
+
+  def pair_factory do
+    {current_year, current_week} = Timex.iso_week(Timex.today)
+    %Pairmotron.Pair{
+      year: current_year,
+      week: current_week,
+      group: build(:group)
+    }
+  end
+
+  def retro_factory do
+    %Pairmotron.PairRetro{
+      pair_date: Timex.today |> Timex.to_erl |> Ecto.Date.from_erl,
+      user: build(:user),
+      pair: build(:pair)
+    }
+  end
 end

--- a/web/controllers/pair_retro_controller.ex
+++ b/web/controllers/pair_retro_controller.ex
@@ -19,7 +19,7 @@ defmodule Pairmotron.PairRetroController do
 
     cond do
       is_nil(pair) ->
-        redirect_and_flash_error(conn, "You cannot create a retrospective for non-existent pair")
+        redirect_and_flash_error(conn, "You cannot create a retrospective for a non-existent pair")
       not current_user.id in Enum.map(pair.users, &(&1.id)) ->
         redirect_and_flash_error(conn, "You cannot create a retrospective for a pair you are not in")
       true ->
@@ -38,7 +38,7 @@ defmodule Pairmotron.PairRetroController do
 
     cond do
       is_nil(pair) ->
-        redirect_and_flash_error(conn, "You cannot create a retrospective for non-existent pair")
+        redirect_and_flash_error(conn, "You cannot create a retrospective for a non-existent pair")
       not current_user.id in Enum.map(pair.users, &(&1.id)) ->
         redirect_and_flash_error(conn, "You cannot create a retrospective for a pair you are not in")
       true ->

--- a/web/controllers/pair_retro_controller.ex
+++ b/web/controllers/pair_retro_controller.ex
@@ -31,9 +31,9 @@ defmodule Pairmotron.PairRetroController do
   end
 
   def create(conn, %{"pair_retro" => pair_retro_params}) do
-    pair_id = parameter_as_integer(pair_retro_params, "pair_id")
     current_user = conn.assigns.current_user
 
+    pair_id = parameter_as_integer(pair_retro_params, "pair_id")
     pair = Pair.pair_with_users(pair_id) |> Repo.one
 
     cond do

--- a/web/controllers/pair_retro_controller.ex
+++ b/web/controllers/pair_retro_controller.ex
@@ -57,9 +57,11 @@ defmodule Pairmotron.PairRetroController do
   end
 
   def update(conn = @authorized_conn, %{"pair_retro" => pair_retro_params}) do
-    earliest_pair_date = earliest_pair_date_from_params(pair_retro_params)
-    pair_retro = conn.assigns.pair_retro
-    changeset = PairRetro.changeset(pair_retro, pair_retro_params, earliest_pair_date)
+    pair_retro = conn.assigns.pair_retro |> Repo.preload(:pair)
+    pair = pair_retro.pair
+
+    earliest_pair_date = Pairmotron.Calendar.first_date_of_week(pair.year, pair.week)
+    changeset = PairRetro.update_changeset(pair_retro, pair_retro_params, earliest_pair_date)
 
     case Repo.update(changeset) do
       {:ok, pair_retro} ->

--- a/web/controllers/pair_retro_controller.ex
+++ b/web/controllers/pair_retro_controller.ex
@@ -1,7 +1,7 @@
 defmodule Pairmotron.PairRetroController do
   use Pairmotron.Web, :controller
 
-  alias Pairmotron.{PairRetro, Project}
+  alias Pairmotron.{PairRetro, Project, Pair}
   import Pairmotron.ControllerHelpers
 
   plug :load_and_authorize_resource, model: PairRetro, only: [:show, :edit, :update, :delete]
@@ -20,21 +20,29 @@ defmodule Pairmotron.PairRetroController do
   end
 
   def create(conn, %{"pair_retro" => pair_retro_params}) do
-    user_id = parameter_as_integer(pair_retro_params, "user_id")
-    current_user = conn.assigns[:current_user]
-    if current_user.id == user_id || user_id == 0 || is_admin?(current_user) do
-      earliest_pair_date = earliest_pair_date_from_params(pair_retro_params)
-      changeset = PairRetro.changeset(%PairRetro{}, pair_retro_params, earliest_pair_date)
-      case Repo.insert(changeset) do
-        {:ok, _pair_retro} ->
-          conn
-          |> put_flash(:info, "Pair retro created successfully.")
-          |> redirect(to: pair_retro_path(conn, :index))
-        {:error, changeset} ->
-          render(conn, "new.html", changeset: changeset)
-      end
-    else
-      redirect_not_authorized(conn, pair_retro_path(conn, :index))
+    pair_id = parameter_as_integer(pair_retro_params, "pair_id")
+    current_user = conn.assigns.current_user
+
+    pair = Repo.get!(Pair, pair_id) |> Repo.preload(:users)
+    pair_user_ids = pair.users |> Enum.map(&(&1.id))
+
+    implicit_params = %{"user_id" => conn.assigns.current_user.id}
+    final_params = pair_retro_params |> Map.merge(implicit_params)
+
+    cond do
+      not current_user.id in pair_user_ids ->
+        redirect_not_authorized(conn, pair_retro_path(conn, :index))
+      true ->
+        earliest_pair_date = earliest_pair_date_from_params(pair_retro_params)
+        changeset = PairRetro.changeset(%PairRetro{}, final_params, earliest_pair_date)
+        case Repo.insert(changeset) do
+          {:ok, _pair_retro} ->
+            conn
+            |> put_flash(:info, "Pair retro created successfully.")
+            |> redirect(to: pair_retro_path(conn, :index))
+          {:error, changeset} ->
+            render(conn, "new.html", changeset: changeset)
+        end
     end
   end
 

--- a/web/controllers/pair_retro_controller.ex
+++ b/web/controllers/pair_retro_controller.ex
@@ -26,13 +26,13 @@ defmodule Pairmotron.PairRetroController do
     pair = Repo.get!(Pair, pair_id) |> Repo.preload(:users)
     pair_user_ids = pair.users |> Enum.map(&(&1.id))
 
-    implicit_params = %{"user_id" => conn.assigns.current_user.id}
-    final_params = pair_retro_params |> Map.merge(implicit_params)
-
     cond do
       not current_user.id in pair_user_ids ->
         redirect_not_authorized(conn, pair_retro_path(conn, :index))
       true ->
+        implicit_params = %{"user_id" => conn.assigns.current_user.id}
+        final_params = pair_retro_params |> Map.merge(implicit_params)
+
         earliest_pair_date = earliest_pair_date_from_params(pair_retro_params)
         changeset = PairRetro.changeset(%PairRetro{}, final_params, earliest_pair_date)
         case Repo.insert(changeset) do

--- a/web/models/pair.ex
+++ b/web/models/pair.ex
@@ -4,15 +4,15 @@ defmodule Pairmotron.Pair do
   schema "pairs" do
     field :year, :integer
     field :week, :integer
-    many_to_many :users, Pairmotron.User, join_through: "users_pairs"
+    many_to_many :users, Pairmotron.User, join_through: Pairmotron.UserPair
     has_many :pair_retros, Pairmotron.PairRetro
     belongs_to :group, Pairmotron.Group
 
-    @required_fields ~w(year week group_id)
-    @optional_fields ~w()
-
     timestamps()
   end
+
+  @required_fields ~w(year week group_id)
+  @optional_fields ~w()
 
   @doc """
   Builds a changeset based on the `struct` and `params`.

--- a/web/models/pair.ex
+++ b/web/models/pair.ex
@@ -26,10 +26,8 @@ defmodule Pairmotron.Pair do
   Ecto query that returns a pair with its :users association prelodaded.
   Performs a single database call.
   """
-  def pair_with_users(pair_id) when is_binary(pair_id) do
-    {pair_id_int, _} = Integer.parse(pair_id)
-    pair_with_users(pair_id_int)
-  end
+  def pair_with_users(pair_id) when is_binary(pair_id), do:
+    Integer.parse(pair_id) |> elem(0) |> pair_with_users
   def pair_with_users(pair_id) do
     from pair in Pairmotron.Pair,
     join: users in assoc(pair, :users),

--- a/web/models/pair.ex
+++ b/web/models/pair.ex
@@ -21,4 +21,19 @@ defmodule Pairmotron.Pair do
     struct
     |> cast(params, @required_fields, @optional_fields)
   end
+
+  @doc """
+  Ecto query that returns a pair with its :users association prelodaded.
+  Performs a single database call.
+  """
+  def pair_with_users(pair_id) when is_binary(pair_id) do
+    {pair_id_int, _} = Integer.parse(pair_id)
+    pair_with_users(pair_id_int)
+  end
+  def pair_with_users(pair_id) do
+    from pair in Pairmotron.Pair,
+    join: users in assoc(pair, :users),
+    where: pair.id == ^pair_id,
+    preload: [users: users]
+  end
 end

--- a/web/models/pair_retro.ex
+++ b/web/models/pair_retro.ex
@@ -34,6 +34,28 @@ defmodule Pairmotron.PairRetro do
     |> validate_field_is_not_in_future(:pair_date)
   end
 
+  @required_update_fields ~w(pair_date)
+
+  @doc """
+  Builds a changeset based on the `struct` and `params`.
+
+  pair_start_date should be a date which is the first day
+  of the week and year on the associated pair. It is used
+  to validate that the pair_date of this pair_retro is after
+  that date, since the actual pairing could not have occurred
+  before the actual pair was assigned.
+
+  The update changeset does not allow the user to change the user or pair
+  associated with the pair_retro.
+  """
+  def update_changeset(struct, params \\ %{}, pair_start_date) do
+    struct
+    |> cast(params, @required_update_fields, @optional_fields)
+    |> foreign_key_constraint(:project_id)
+    |> validate_field_is_not_before_date(:pair_date, pair_start_date)
+    |> validate_field_is_not_in_future(:pair_date)
+  end
+
   defp validate_field_is_not_before_date(changeset, field, pair_start_date) do
     validate_change changeset, field, fn field, field_date ->
       cond do

--- a/web/templates/pair_retro/form.html.eex
+++ b/web/templates/pair_retro/form.html.eex
@@ -6,7 +6,6 @@
   <% end %>
 
   <%= hidden_input f, :pair_id, value: value_from_changeset(@changeset, :pair_id) %>
-  <%= hidden_input f, :user_id, value: value_from_changeset(@changeset, :user_id) %>
 
   <div class="form-group">
     <%= label f, :pair_date, class: "control-label" %>


### PR DESCRIPTION
Fixes manually being able to hit the :update route to update the user or
pair of a retrospective by removing that from the cast parameters
available in an update action to the changeset.

Fix being able to update the pair_date to a date before the date of a
pair if the pair_id parameter was not explicitly supplied.

Add pair and retro ex machina factories

Refactor pair_retro controller tests to use more ex machina and divide
out the actions into their own describe blocks

Disallow creation of retrospectives for pairs that the logged in user is not apart of (through both :new and :create actions).

Closes #53