### PR TITLE
Improve admin usage of /groups

### DIFF
--- a/web/templates/group/group_actions.html.eex
+++ b/web/templates/group/group_actions.html.eex
@@ -1,24 +1,26 @@
-<%= cond do %>
-  <%= current_user_has_been_invited_by_group?(@conn, @group) -> %>
-    <%= render Pairmotron.UsersGroupMembershipRequestView,
-          "accept_invitation_form.html",
-          conn: @conn,
-          action: users_group_membership_request_path(@conn, :update, current_user_group_membership_request_for_group(@conn, @group)) %>
-  <%= current_user_in_group?(@conn, @group) -> %>
-    <%= link "Pairs", to: group_pair_path(@conn, :show, @group), class: "btn btn-default btn-sm"%>
-  <%= not current_user_in_group?(@conn, @group) and not current_user_has_requested_membership_to_group?(@conn, @group) -> %>
-    <%= render "request_membership_form.html",
-    changeset: Pairmotron.GroupMembershipRequest.changeset(%Pairmotron.GroupMembershipRequest{}, %{group_id: @group.id}),
-          action: users_group_membership_request_path(@conn, :create) %>
-  <%= true -> %>
-<%= end %>
+<div class="form-group">
+  <%= cond do %>
+    <%= current_user_has_been_invited_by_group?(@conn, @group) -> %>
+      <%= render Pairmotron.UsersGroupMembershipRequestView,
+            "accept_invitation_form.html",
+            conn: @conn,
+            action: users_group_membership_request_path(@conn, :update, current_user_group_membership_request_for_group(@conn, @group)) %>
+    <%= current_user_in_group?(@conn, @group) -> %>
+      <%= link "Pairs", to: group_pair_path(@conn, :show, @group), class: "btn btn-default btn-sm"%>
+    <%= not current_user_in_group?(@conn, @group) and not current_user_has_requested_membership_to_group?(@conn, @group) -> %>
+      <%= render "request_membership_form.html",
+      changeset: Pairmotron.GroupMembershipRequest.changeset(%Pairmotron.GroupMembershipRequest{}, %{group_id: @group.id}),
+            action: users_group_membership_request_path(@conn, :create) %>
+    <%= true -> %>
+  <%= end %>
 
-<%= if current_user_can_edit_group?(@conn, @group) do %>
-  <a href=<%= group_invitation_path(@conn, :index, @group) %>>
-    <button class="btn btn-primary btn-sm">Invitations</button>
-  </a>
-  <a href=<%= group_path(@conn, :edit, @group) %>>
-    <button class="btn btn-primary btn-sm">Edit</button>
-  </a>
-  <%= link "Delete", to: group_path(@conn, :delete, @group), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-sm" %>
-<%= end %>
+  <%= if current_user_can_edit_group?(@conn, @group) do %>
+    <a href=<%= group_invitation_path(@conn, :index, @group) %>>
+      <button class="btn btn-primary btn-sm">Invitations</button>
+    </a>
+    <a href=<%= group_path(@conn, :edit, @group) %>>
+      <button class="btn btn-primary btn-sm">Edit</button>
+    </a>
+    <%= link "Delete", to: group_path(@conn, :delete, @group), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-sm" %>
+  <%= end %>
+</div>

--- a/web/templates/group/index.html.eex
+++ b/web/templates/group/index.html.eex
@@ -8,7 +8,7 @@
           <h4><%= link group.name, to: group_path(@conn, :show, group) %>
             <small>
               <%= cond do %>
-                <%= current_user_can_edit_group?(@conn, group) -> %>
+                <%= group.owner_id == @conn.assigns.current_user.id -> %>
                   <label class="label label-info">Owner</label>
                 <%= current_user_in_group?(@conn, group) -> %>
                   <label class="label label-success">Member</label>

--- a/web/templates/group/request_membership_form.html.eex
+++ b/web/templates/group/request_membership_form.html.eex
@@ -1,6 +1,6 @@
 <%= form_for @changeset, @action, fn f -> %>
-
-  <%= hidden_input f, :group_id, value: value_from_changeset(@changeset, :group_id) %>
-
-  <%= submit "Request Membership", class: "btn btn-primary btn-sm" %>
+  <div class="form-group">
+    <%= hidden_input f, :group_id, value: value_from_changeset(@changeset, :group_id) %>
+    <%= submit "Request Membership", class: "btn btn-primary btn-sm" %>
+  </div>
 <% end %>

--- a/web/templates/group/show.html.eex
+++ b/web/templates/group/show.html.eex
@@ -1,7 +1,7 @@
 <h2><%= link @group.name, to: group_path(@conn, :show, @group) %>
   <small>
     <%= cond do %>
-      <%= current_user_can_edit_group?(@conn, @group) -> %>
+      <%= @group.owner_id == @conn.assigns.current_user.id -> %>
         <label class="label label-info">Owner</label>
       <%= current_user_in_group?(@conn, @group) -> %>
         <label class="label label-success">Member</label>

--- a/web/templates/users_group_membership_request/accept_invitation_form.html.eex
+++ b/web/templates/users_group_membership_request/accept_invitation_form.html.eex
@@ -1,3 +1,5 @@
 <%= form_for @conn, @action, [as: :accept, method: "PUT"], fn _f -> %>
-  <%= submit "Accept Invitation", class: "btn btn-success btn-sm" %>
+  <div class="form-group">
+    <%= submit "Accept Invitation", class: "btn btn-success btn-sm" %>
+  </div>
 <% end %>


### PR DESCRIPTION
@mbramson This fixes a few UX issue with groups if you are an admin user. Mostly added some spacing around the form elements in the group boxes, as admins have more buttons that normal. Also noted some odd behavior as admin for labels that I missed before.