### PR TITLE
Replace projects conn assign with parameter

### DIFF
--- a/test/controllers/pair_retro_controller_test.exs
+++ b/test/controllers/pair_retro_controller_test.exs
@@ -233,12 +233,34 @@ defmodule Pairmotron.PairRetroControllerTest do
       group = insert(:group, %{owner: user, users: [user]})
       pair = insert(:pair, %{group: group, users: [user]})
       retro = insert(:retro, %{user: user, pair: pair})
+
       conn = get conn, pair_retro_path(conn, :edit, retro)
       assert html_response(conn, 200) =~ "Edit retrospective"
     end
 
+    test "lists a project associated with the retro's pair's group", %{conn: conn, logged_in_user: user} do
+      group = insert(:group)
+      pair = insert(:pair, %{group: group, users: [user]})
+      project = insert(:project, %{group: group})
+      retro = insert(:retro, %{user: user, pair: pair})
+
+      conn = get conn, pair_retro_path(conn, :edit, retro)
+      assert html_response(conn, 200) =~ project.name
+    end
+
+    test "does not list a project not associated with the retro's pair's group", %{conn: conn, logged_in_user: user} do
+      group = insert(:group)
+      pair = insert(:pair, %{group: group, users: [user]})
+      project = insert(:project)
+      retro = insert(:retro, %{user: user, pair: pair})
+
+      conn = get conn, pair_retro_path(conn, :edit, retro)
+      refute html_response(conn, 200) =~ project.name
+    end
+
     test "does not render form for editing different user's resource", %{conn: conn} do
       {_user, _pair, retro} = create_user_and_pair_and_retro()
+
       conn = get conn, pair_retro_path(conn, :edit, retro)
       assert redirected_to(conn) == pair_retro_path(conn, :index)
       assert %{"error" => _} = conn.private.phoenix_flash

--- a/test/models/pair_retro_test.exs
+++ b/test/models/pair_retro_test.exs
@@ -1,54 +1,55 @@
 defmodule Pairmotron.PairRetroTest do
   use Pairmotron.ModelCase
-  import Pairmotron.TestHelper, only: [create_pair: 4, create_retro: 2]
   alias Pairmotron.PairRetro
 
   @valid_attrs %{subject: "subject", reflection: "reflection", pair_date: Timex.today}
   @invalid_attrs %{}
 
-  test "changeset with valid attributes" do
-    user = insert(:user)
-    group = insert(:group, %{owner: user})
-    pair = Pairmotron.TestHelper.create_pair([user], group)
-    attrs = Map.merge(@valid_attrs, %{user_id: user.id,
-                                      pair_id: pair.id})
-    changeset = PairRetro.changeset(%PairRetro{}, attrs, Timex.today)
-    assert changeset.valid?
-  end
+  describe "changeset" do
+    test "changeset with valid attributes" do
+      user = insert(:user)
+      group = insert(:group, %{owner: user})
+      pair = insert(:pair, %{users: [user], group: group})
+      attrs = Map.merge(@valid_attrs, %{user_id: user.id,
+                                        pair_id: pair.id})
+      changeset = PairRetro.changeset(%PairRetro{}, attrs, Timex.today)
+      assert changeset.valid?
+    end
 
-  test "changeset with a pair that occurred after the pair_date is invalid" do
-    user = insert(:user)
-    group = insert(:group, %{owner: user})
-    pair = create_pair([user], group, 2016, 1)
-    attrs = Map.merge(@valid_attrs, %{pair_date: ~D(2011-01-01),
-                                      user_id: user.id,
-                                      pair_id: pair.id})
-    changeset = PairRetro.changeset(%PairRetro{}, attrs, ~D(2016-01-04))
-    refute changeset.valid?
-  end
+    test "changeset with a pair that occurred after the pair_date is invalid" do
+      user = insert(:user)
+      group = insert(:group, %{owner: user})
+      pair = insert(:pair, %{users: [user], group: group, year: 2016, week: 1})
+      attrs = Map.merge(@valid_attrs, %{pair_date: ~D(2011-01-01),
+                                        user_id: user.id,
+                                        pair_id: pair.id})
+      changeset = PairRetro.changeset(%PairRetro{}, attrs, ~D(2016-01-04))
+      refute changeset.valid?
+    end
 
-  test "changeset with a pair_date in the future is invalid" do
-    user = insert(:user)
-    group = insert(:group, %{owner: user})
-    pair = Pairmotron.TestHelper.create_pair([user], group)
-    attrs = Map.merge(@valid_attrs, %{pair_date: Timex.shift(Timex.today, days: 1),
-                                      user_id: user.id,
-                                      pair_id: pair.id})
-    changeset = PairRetro.changeset(%PairRetro{}, attrs, nil)
-    refute changeset.valid?
-  end
+    test "changeset with a pair_date in the future is invalid" do
+      user = insert(:user)
+      group = insert(:group, %{owner: user})
+      pair = insert(:pair, %{users: [user], group: group})
+      attrs = Map.merge(@valid_attrs, %{pair_date: Timex.shift(Timex.today, days: 1),
+                                        user_id: user.id,
+                                        pair_id: pair.id})
+      changeset = PairRetro.changeset(%PairRetro{}, attrs, nil)
+      refute changeset.valid?
+    end
 
-  test "changeset with invalid attributes" do
-    changeset = PairRetro.changeset(%PairRetro{}, @invalid_attrs, nil)
-    refute changeset.valid?
+    test "changeset with invalid attributes" do
+      changeset = PairRetro.changeset(%PairRetro{}, @invalid_attrs, nil)
+      refute changeset.valid?
+    end
   end
 
   describe ".retro_for_user_and_week" do
     test "returns the retro for the user for the pair for the given week" do
       user = insert(:user)
       group = insert(:group, %{owner: user})
-      pair = create_pair([user], group, 2016, 25)
-      retro = create_retro(user, pair)
+      pair = insert(:pair, %{users: [user], group: group, year: 2016, week: 25})
+      retro = insert(:retro, %{user: user, pair: pair})
       returned_retro = Repo.one(PairRetro.retro_for_user_and_week(user, 2016, 25))
       assert returned_retro.id == retro.id
     end
@@ -56,22 +57,22 @@ defmodule Pairmotron.PairRetroTest do
     test "returns nil when there has been a retro for the user but on the wrong week" do
       user = insert(:user)
       group = insert(:group, %{owner: user})
-      pair = create_pair([user], group, 2016, 25)
-      create_retro(user, pair)
+      pair = insert(:pair, %{users: [user], group: group, year: 2016, week: 25})
+      insert(:retro, %{user: user, pair: pair})
       refute Repo.one(PairRetro.retro_for_user_and_week(user, 1999, 10))
     end
 
     test "returns nil when there has been no retro for the user for the given week" do
       user = insert(:user)
       group = insert(:group, %{owner: user})
-      create_pair([user], group, 2016, 25)
+      insert(:pair, %{users: [user], group: group, year: 2016, week: 25})
       refute Repo.one(PairRetro.retro_for_user_and_week(user, 2016, 25))
     end
 
     test "returns nil when there has been no pair for the user for the given week" do
       user = insert(:user)
       group = insert(:group, %{owner: user})
-      create_pair([user], group, 2016, 25)
+      insert(:pair, %{users: [user], group: group, year: 2016, week: 25})
       refute Repo.one(PairRetro.retro_for_user_and_week(user, 1999, 10))
     end
 
@@ -90,8 +91,8 @@ defmodule Pairmotron.PairRetroTest do
     test "returns the retro that is assigned to the passed in user" do
       user = insert(:user)
       group = insert(:group, %{owner: user})
-      pair = Pairmotron.TestHelper.create_pair([user], group)
-      retro = create_retro(user, pair)
+      pair = insert(:pair, %{users: [user], group: group})
+      retro = insert(:retro, %{user: user, pair: pair})
       returned_retro = Repo.one(PairRetro.users_retros(user))
       assert returned_retro.id == retro.id
     end
@@ -99,8 +100,8 @@ defmodule Pairmotron.PairRetroTest do
     test "does not return a retro for a different user" do
       [retro_user, other_user] = insert_pair(:user)
       group = insert(:group, %{owner: retro_user})
-      pair = Pairmotron.TestHelper.create_pair([retro_user], group)
-      create_retro(retro_user, pair)
+      pair = insert(:pair, %{users: [retro_user], group: group})
+      insert(:retro, %{user: retro_user, pair: pair})
       refute Repo.one(PairRetro.users_retros(other_user))
     end
   end

--- a/test/models/pair_retro_test.exs
+++ b/test/models/pair_retro_test.exs
@@ -12,7 +12,7 @@ defmodule Pairmotron.PairRetroTest do
       pair = insert(:pair, %{users: [user], group: group})
       attrs = Map.merge(@valid_attrs, %{user_id: user.id,
                                         pair_id: pair.id})
-      changeset = PairRetro.changeset(%PairRetro{}, attrs, Timex.today)
+      changeset = PairRetro.changeset(%PairRetro{}, attrs, Timex.today, nil, nil)
       assert changeset.valid?
     end
 
@@ -23,7 +23,7 @@ defmodule Pairmotron.PairRetroTest do
       attrs = Map.merge(@valid_attrs, %{pair_date: ~D(2011-01-01),
                                         user_id: user.id,
                                         pair_id: pair.id})
-      changeset = PairRetro.changeset(%PairRetro{}, attrs, ~D(2016-01-04))
+      changeset = PairRetro.changeset(%PairRetro{}, attrs, ~D(2016-01-04), nil, nil)
       refute changeset.valid?
     end
 
@@ -34,12 +34,12 @@ defmodule Pairmotron.PairRetroTest do
       attrs = Map.merge(@valid_attrs, %{pair_date: Timex.shift(Timex.today, days: 1),
                                         user_id: user.id,
                                         pair_id: pair.id})
-      changeset = PairRetro.changeset(%PairRetro{}, attrs, nil)
+      changeset = PairRetro.changeset(%PairRetro{}, attrs, nil, nil, nil)
       refute changeset.valid?
     end
 
     test "changeset with invalid attributes" do
-      changeset = PairRetro.changeset(%PairRetro{}, @invalid_attrs, nil)
+      changeset = PairRetro.changeset(%PairRetro{}, @invalid_attrs, nil, nil, nil)
       refute changeset.valid?
     end
   end

--- a/test/models/pair_retro_test.exs
+++ b/test/models/pair_retro_test.exs
@@ -12,7 +12,7 @@ defmodule Pairmotron.PairRetroTest do
       pair = insert(:pair, %{users: [user], group: group})
       attrs = Map.merge(@valid_attrs, %{user_id: user.id,
                                         pair_id: pair.id})
-      changeset = PairRetro.changeset(%PairRetro{}, attrs, Timex.today, nil, nil)
+      changeset = PairRetro.changeset(%PairRetro{}, attrs, nil, pair)
       assert changeset.valid?
     end
 
@@ -23,7 +23,7 @@ defmodule Pairmotron.PairRetroTest do
       attrs = Map.merge(@valid_attrs, %{pair_date: ~D(2011-01-01),
                                         user_id: user.id,
                                         pair_id: pair.id})
-      changeset = PairRetro.changeset(%PairRetro{}, attrs, ~D(2016-01-04), nil, nil)
+      changeset = PairRetro.changeset(%PairRetro{}, attrs, nil, pair)
       refute changeset.valid?
     end
 
@@ -34,12 +34,12 @@ defmodule Pairmotron.PairRetroTest do
       attrs = Map.merge(@valid_attrs, %{pair_date: Timex.shift(Timex.today, days: 1),
                                         user_id: user.id,
                                         pair_id: pair.id})
-      changeset = PairRetro.changeset(%PairRetro{}, attrs, nil, nil, nil)
+      changeset = PairRetro.changeset(%PairRetro{}, attrs, nil, pair)
       refute changeset.valid?
     end
 
     test "changeset with invalid attributes" do
-      changeset = PairRetro.changeset(%PairRetro{}, @invalid_attrs, nil, nil, nil)
+      changeset = PairRetro.changeset(%PairRetro{}, @invalid_attrs, nil, nil)
       refute changeset.valid?
     end
   end

--- a/test/models/pair_retro_test.exs
+++ b/test/models/pair_retro_test.exs
@@ -12,7 +12,7 @@ defmodule Pairmotron.PairRetroTest do
       pair = insert(:pair, %{users: [user], group: group})
       attrs = Map.merge(@valid_attrs, %{user_id: user.id,
                                         pair_id: pair.id})
-      changeset = PairRetro.changeset(%PairRetro{}, attrs, nil, pair)
+      changeset = PairRetro.changeset(%PairRetro{}, attrs, pair, nil)
       assert changeset.valid?
     end
 
@@ -23,7 +23,7 @@ defmodule Pairmotron.PairRetroTest do
       attrs = Map.merge(@valid_attrs, %{pair_date: ~D(2011-01-01),
                                         user_id: user.id,
                                         pair_id: pair.id})
-      changeset = PairRetro.changeset(%PairRetro{}, attrs, nil, pair)
+      changeset = PairRetro.changeset(%PairRetro{}, attrs, pair, nil)
       refute changeset.valid?
     end
 
@@ -34,7 +34,7 @@ defmodule Pairmotron.PairRetroTest do
       attrs = Map.merge(@valid_attrs, %{pair_date: Timex.shift(Timex.today, days: 1),
                                         user_id: user.id,
                                         pair_id: pair.id})
-      changeset = PairRetro.changeset(%PairRetro{}, attrs, nil, pair)
+      changeset = PairRetro.changeset(%PairRetro{}, attrs, pair, nil)
       refute changeset.valid?
     end
 

--- a/test/models/pair_test.exs
+++ b/test/models/pair_test.exs
@@ -14,4 +14,50 @@ defmodule Pairmotron.PairTest do
     changeset = Pair.changeset(%Pair{}, @invalid_attrs)
     refute changeset.valid?
   end
+
+  describe "pair_with_users_and_group/1" do
+    test "returns nil when no pair exists" do
+      assert Pair.pair_with_users_and_group(1) |> Repo.one == nil
+    end
+
+    test "returns the pair if it exists with preloaded group and users" do
+      user = insert(:user)
+      group = insert(:group)
+      pair = insert(:pair, %{users: [user], group: group})
+      returned_pair = Pair.pair_with_users_and_group(pair.id) |> Repo.one
+      assert Enum.at(returned_pair.users, 0).id == user.id
+      assert returned_pair.group.id == pair.group.id
+    end
+
+    test "returns the pair if it exists and has no users" do
+      pair = insert(:pair)
+      returned_pair = Pair.pair_with_users_and_group(pair.id) |> Repo.one
+      assert returned_pair.id == pair.id
+      assert returned_pair.users == []
+      assert returned_pair.group.id == pair.group.id
+    end
+
+    test "returns the pair if it exists and has no group" do
+      user = insert(:user)
+      pair = insert(:pair, %{users: [user], group: nil})
+      returned_pair = Pair.pair_with_users_and_group(pair.id) |> Repo.one
+      assert returned_pair.id == pair.id
+      assert Enum.at(returned_pair.users, 0).id == user.id
+      assert returned_pair.group == nil
+    end
+
+    test "returns the pair if it exists and has no users or group" do
+      pair = insert(:pair, %{group: nil})
+      returned_pair = Pair.pair_with_users_and_group(pair.id) |> Repo.one
+      assert returned_pair.id == pair.id
+      assert returned_pair.users == []
+      assert returned_pair.group == nil
+    end
+
+    test "returns the pair if passed a binary" do
+      pair = insert(:pair)
+      returned_pair = Pair.pair_with_users_and_group("#{pair.id}") |> Repo.one
+      assert returned_pair.id == pair.id
+    end
+  end
 end

--- a/test/models/pair_test.exs
+++ b/test/models/pair_test.exs
@@ -5,14 +5,47 @@ defmodule Pairmotron.PairTest do
   @valid_attrs %{group_id: 42, week: 42, year: 42}
   @invalid_attrs %{}
 
-  test "changeset with valid attributes" do
-    changeset = Pair.changeset(%Pair{}, @valid_attrs)
-    assert changeset.valid?
+  describe "changeset" do
+    test "changeset with valid attributes" do
+      changeset = Pair.changeset(%Pair{}, @valid_attrs)
+      assert changeset.valid?
+    end
+
+    test "changeset with invalid attributes" do
+      changeset = Pair.changeset(%Pair{}, @invalid_attrs)
+      refute changeset.valid?
+    end
   end
 
-  test "changeset with invalid attributes" do
-    changeset = Pair.changeset(%Pair{}, @invalid_attrs)
-    refute changeset.valid?
+  describe "pair_with_users/1" do
+    test "returns nil when no pair exists" do
+      assert Pair.pair_with_users(1) |> Repo.one == nil
+    end
+
+    test "returns the pair if it exists with preloaded users" do
+      user = insert(:user)
+      pair = insert(:pair, %{users: [user]})
+
+      returned_pair = Pair.pair_with_users_and_group(pair.id) |> Repo.one
+      assert returned_pair.id == pair.id
+      assert Enum.at(returned_pair.users, 0).id == user.id
+    end
+
+    test "returns the pair if it exists and there are no associated users" do
+      pair = insert(:pair, %{users: []})
+
+      returned_pair = Pair.pair_with_users_and_group(pair.id) |> Repo.one
+      assert returned_pair.id == pair.id
+      assert returned_pair.users == []
+    end
+
+    test "returns the pair if given pair_id is binary" do
+      pair = insert(:pair, %{users: []})
+
+      returned_pair = Pair.pair_with_users_and_group("#{pair.id}") |> Repo.one
+      assert returned_pair.id == pair.id
+      assert returned_pair.users == []
+    end
   end
 
   describe "pair_with_users_and_group/1" do

--- a/test/models/pair_test.exs
+++ b/test/models/pair_test.exs
@@ -26,7 +26,7 @@ defmodule Pairmotron.PairTest do
       user = insert(:user)
       pair = insert(:pair, %{users: [user]})
 
-      returned_pair = Pair.pair_with_users_and_group(pair.id) |> Repo.one
+      returned_pair = Pair.pair_with_users(pair.id) |> Repo.one
       assert returned_pair.id == pair.id
       assert Enum.at(returned_pair.users, 0).id == user.id
     end
@@ -34,7 +34,7 @@ defmodule Pairmotron.PairTest do
     test "returns the pair if it exists and there are no associated users" do
       pair = insert(:pair, %{users: []})
 
-      returned_pair = Pair.pair_with_users_and_group(pair.id) |> Repo.one
+      returned_pair = Pair.pair_with_users(pair.id) |> Repo.one
       assert returned_pair.id == pair.id
       assert returned_pair.users == []
     end
@@ -42,55 +42,9 @@ defmodule Pairmotron.PairTest do
     test "returns the pair if given pair_id is binary" do
       pair = insert(:pair, %{users: []})
 
-      returned_pair = Pair.pair_with_users_and_group("#{pair.id}") |> Repo.one
+      returned_pair = Pair.pair_with_users("#{pair.id}") |> Repo.one
       assert returned_pair.id == pair.id
       assert returned_pair.users == []
-    end
-  end
-
-  describe "pair_with_users_and_group/1" do
-    test "returns nil when no pair exists" do
-      assert Pair.pair_with_users_and_group(1) |> Repo.one == nil
-    end
-
-    test "returns the pair if it exists with preloaded group and users" do
-      user = insert(:user)
-      group = insert(:group)
-      pair = insert(:pair, %{users: [user], group: group})
-      returned_pair = Pair.pair_with_users_and_group(pair.id) |> Repo.one
-      assert Enum.at(returned_pair.users, 0).id == user.id
-      assert returned_pair.group.id == pair.group.id
-    end
-
-    test "returns the pair if it exists and has no users" do
-      pair = insert(:pair)
-      returned_pair = Pair.pair_with_users_and_group(pair.id) |> Repo.one
-      assert returned_pair.id == pair.id
-      assert returned_pair.users == []
-      assert returned_pair.group.id == pair.group.id
-    end
-
-    test "returns the pair if it exists and has no group" do
-      user = insert(:user)
-      pair = insert(:pair, %{users: [user], group: nil})
-      returned_pair = Pair.pair_with_users_and_group(pair.id) |> Repo.one
-      assert returned_pair.id == pair.id
-      assert Enum.at(returned_pair.users, 0).id == user.id
-      assert returned_pair.group == nil
-    end
-
-    test "returns the pair if it exists and has no users or group" do
-      pair = insert(:pair, %{group: nil})
-      returned_pair = Pair.pair_with_users_and_group(pair.id) |> Repo.one
-      assert returned_pair.id == pair.id
-      assert returned_pair.users == []
-      assert returned_pair.group == nil
-    end
-
-    test "returns the pair if passed a binary" do
-      pair = insert(:pair)
-      returned_pair = Pair.pair_with_users_and_group("#{pair.id}") |> Repo.one
-      assert returned_pair.id == pair.id
     end
   end
 end

--- a/test/models/project_test.exs
+++ b/test/models/project_test.exs
@@ -15,4 +15,21 @@ defmodule Pairmotron.ProjectTest do
     changeset = Project.changeset(%Project{}, @invalid_attrs)
     refute changeset.valid?
   end
+
+  describe "projects_for_group" do
+    test "returns nothing when there are no projects" do
+      assert Project.projects_for_group(1) |> Repo.one == nil
+    end
+
+    test "returns a project that is associated with the given group" do
+      group = insert(:group)
+      project = insert(:project, %{group: group})
+      assert Repo.one(Project.projects_for_group(group.id)).id == project.id
+    end
+
+    test "does not return a project that is not associated with the given group" do
+      project = insert(:project)
+      assert Project.projects_for_group(1) |> Repo.one == nil
+    end
+  end
 end

--- a/test/models/project_test.exs
+++ b/test/models/project_test.exs
@@ -28,7 +28,7 @@ defmodule Pairmotron.ProjectTest do
     end
 
     test "does not return a project that is not associated with the given group" do
-      project = insert(:project)
+      insert(:project)
       assert Project.projects_for_group(1) |> Repo.one == nil
     end
   end

--- a/test/support/test_helper.ex
+++ b/test/support/test_helper.ex
@@ -39,7 +39,6 @@ defmodule Pairmotron.TestHelper do
                                             pair_date:  Timex.today,
                                             user_id:    user.id,
                                             pair_id:    pair.id},
-                                          Timex.today,
                                           nil,
                                           nil)
     Repo.insert!(retro_changeset)
@@ -53,7 +52,6 @@ defmodule Pairmotron.TestHelper do
                                             user_id: user.id,
                                             pair_id: pair.id,
                                             project_id: project.id},
-                                          Timex.today,
                                           nil,
                                           nil)
     Repo.insert!(retro_changeset)

--- a/test/support/test_helper.ex
+++ b/test/support/test_helper.ex
@@ -39,7 +39,9 @@ defmodule Pairmotron.TestHelper do
                                             pair_date:  Timex.today,
                                             user_id:    user.id,
                                             pair_id:    pair.id},
-                                          Timex.today)
+                                          Timex.today,
+                                          nil,
+                                          nil)
     Repo.insert!(retro_changeset)
   end
 
@@ -51,7 +53,9 @@ defmodule Pairmotron.TestHelper do
                                             user_id: user.id,
                                             pair_id: pair.id,
                                             project_id: project.id},
-                                          Timex.today)
+                                          Timex.today,
+                                          nil,
+                                          nil)
     Repo.insert!(retro_changeset)
   end
 

--- a/test/views/pair_retro_view_test.exs
+++ b/test/views/pair_retro_view_test.exs
@@ -2,16 +2,18 @@ defmodule Pairmotron.PairRetroViewTest do
   use Pairmotron.ConnCase, async: true
   alias Pairmotron.PairRetroView
 
-  test "returns an empty array when there is no projects field in the conn assign" do
-    conn = build_conn()
-    assert PairRetroView.projects_for_select(conn) == []
-  end
+  describe "projects_as_select/1" do
+    test "returns an empty array when given an empty array of projects" do
+      assert PairRetroView.projects_as_select([]) == []
+    end
 
-  test "returns an array of projects when there are projects in the conn assign" do
-    conn = build_conn()
-    project = insert(:project)
-    conn = Plug.Conn.assign(conn, :projects, [project])
-    expected_projects = ["#{project.name}": project.id]
-    assert PairRetroView.projects_for_select(conn) == expected_projects
+    test "return an array formatted for a dropdown when given an array of projects" do
+      project_1 = build(:project, %{id: 1})
+      project_2 = build(:project, %{id: 2})
+      projects = [project_1, project_2]
+      expected_projects = ["#{project_1.name}": project_1.id,
+                           "#{project_2.name}": project_2.id]
+      assert PairRetroView.projects_as_select(projects) == expected_projects
+    end
   end
 end

--- a/web/controllers/pair_retro_controller.ex
+++ b/web/controllers/pair_retro_controller.ex
@@ -71,8 +71,8 @@ defmodule Pairmotron.PairRetroController do
   end
 
   def edit(conn = @authorized_conn, _params) do
-    projects = Repo.all(Project)
-    retro = conn.assigns.pair_retro
+    retro = conn.assigns.pair_retro |> Repo.preload(:pair)
+    projects = Project.projects_for_group(retro.pair.group_id) |> Repo.all
     changeset = PairRetro.changeset(retro, %{}, nil, nil, nil)
     render(conn, "edit.html", pair_retro: retro, changeset: changeset, projects: projects)
   end

--- a/web/controllers/pair_retro_controller.ex
+++ b/web/controllers/pair_retro_controller.ex
@@ -56,7 +56,7 @@ defmodule Pairmotron.PairRetroController do
             |> put_flash(:info, "Pair retro created successfully.")
             |> redirect(to: pair_retro_path(conn, :index))
           {:error, changeset} ->
-            projects = Repo.all(Project)
+            projects = Project.projects_for_group(pair.group_id) |> Repo.all
             render(conn, "new.html", changeset: changeset, projects: projects)
         end
     end

--- a/web/controllers/pair_retro_controller.ex
+++ b/web/controllers/pair_retro_controller.ex
@@ -102,8 +102,10 @@ defmodule Pairmotron.PairRetroController do
   end
 
   defp project_from_params_or_pair_retro(params, pair_retro) do
-    id = Map.get(params, "project_id") || (pair_retro.project && pair_retro.project.id) || 0
-    Repo.get(Project, id)
+    case Map.get(params, "project_id") || (pair_retro.project && pair_retro.project.id) do
+      nil -> nil
+      id -> Repo.get(Project, id)
+    end
   end
 
   def delete(conn = @authorized_conn, _params) do

--- a/web/controllers/pair_retro_controller.ex
+++ b/web/controllers/pair_retro_controller.ex
@@ -48,7 +48,7 @@ defmodule Pairmotron.PairRetroController do
         project_id = Map.get(final_params, "project_id", 0)
         project = Repo.get(Project, project_id)
 
-        changeset = PairRetro.changeset(%PairRetro{}, final_params, project, pair)
+        changeset = PairRetro.changeset(%PairRetro{}, final_params, pair, project)
         case Repo.insert(changeset) do
           {:ok, _pair_retro} ->
             conn
@@ -86,7 +86,7 @@ defmodule Pairmotron.PairRetroController do
     project_id = Map.get(pair_retro_params, "project_id") || (pair_retro.project && pair_retro.project.id) || 0
     project = Repo.get(Project, project_id)
 
-    changeset = PairRetro.update_changeset(pair_retro, pair_retro_params, project, pair)
+    changeset = PairRetro.update_changeset(pair_retro, pair_retro_params, pair, project)
 
     case Repo.update(changeset) do
       {:ok, pair_retro} ->

--- a/web/controllers/pair_retro_controller.ex
+++ b/web/controllers/pair_retro_controller.ex
@@ -23,10 +23,10 @@ defmodule Pairmotron.PairRetroController do
       not current_user.id in Enum.map(pair.users, &(&1.id)) ->
         redirect_and_flash_error(conn, "You cannot create a retrospective for a pair you are not in")
       true ->
-        conn = assign(conn, :projects, Repo.all(Project))
+        projects = Repo.all(Project)
         current_user = conn.assigns[:current_user]
         changeset = PairRetro.changeset(%PairRetro{}, %{pair_id: pair_id, user_id: current_user.id}, nil)
-        render(conn, "new.html", changeset: changeset)
+        render(conn, "new.html", changeset: changeset, projects: projects)
     end
   end
 
@@ -53,7 +53,8 @@ defmodule Pairmotron.PairRetroController do
             |> put_flash(:info, "Pair retro created successfully.")
             |> redirect(to: pair_retro_path(conn, :index))
           {:error, changeset} ->
-            render(conn, "new.html", changeset: changeset)
+            projects = Repo.all(Project)
+            render(conn, "new.html", changeset: changeset, projects: projects)
         end
     end
   end
@@ -67,10 +68,10 @@ defmodule Pairmotron.PairRetroController do
   end
 
   def edit(conn = @authorized_conn, _params) do
-    conn = assign(conn, :projects, Repo.all(Project))
+    projects = Repo.all(Project)
     retro = conn.assigns.pair_retro
     changeset = PairRetro.changeset(retro, %{}, nil)
-    render(conn, "edit.html", pair_retro: retro, changeset: changeset)
+    render(conn, "edit.html", pair_retro: retro, changeset: changeset, projects: projects)
   end
   def edit(conn, _params) do
     redirect_not_authorized(conn, pair_retro_path(conn, :index))
@@ -89,7 +90,8 @@ defmodule Pairmotron.PairRetroController do
         |> put_flash(:info, "Pair retro updated successfully.")
         |> redirect(to: pair_retro_path(conn, :show, pair_retro))
       {:error, changeset} ->
-        render(conn, "edit.html", pair_retro: pair_retro, changeset: changeset)
+        projects = Repo.all(Project)
+        render(conn, "edit.html", pair_retro: pair_retro, changeset: changeset, projects: projects)
     end
   end
   def update(conn, _params) do

--- a/web/controllers/pair_retro_controller.ex
+++ b/web/controllers/pair_retro_controller.ex
@@ -25,7 +25,7 @@ defmodule Pairmotron.PairRetroController do
       true ->
         projects = Project.projects_for_group(pair.group_id) |> Repo.all
         current_user = conn.assigns[:current_user]
-        changeset = PairRetro.changeset(%PairRetro{}, %{pair_id: pair_id, user_id: current_user.id}, nil, nil, nil)
+        changeset = PairRetro.changeset(%PairRetro{}, %{pair_id: pair_id, user_id: current_user.id}, nil, nil)
         render(conn, "new.html", changeset: changeset, projects: projects)
     end
   end
@@ -48,8 +48,7 @@ defmodule Pairmotron.PairRetroController do
         project_id = Map.get(final_params, "project_id", 0)
         project = Repo.get(Project, project_id)
 
-        earliest_pair_date = earliest_pair_date_from_params(pair_retro_params)
-        changeset = PairRetro.changeset(%PairRetro{}, final_params, earliest_pair_date, project, pair)
+        changeset = PairRetro.changeset(%PairRetro{}, final_params, project, pair)
         case Repo.insert(changeset) do
           {:ok, _pair_retro} ->
             conn
@@ -73,7 +72,7 @@ defmodule Pairmotron.PairRetroController do
   def edit(conn = @authorized_conn, _params) do
     retro = conn.assigns.pair_retro |> Repo.preload(:pair)
     projects = Project.projects_for_group(retro.pair.group_id) |> Repo.all
-    changeset = PairRetro.changeset(retro, %{}, nil, nil, nil)
+    changeset = PairRetro.changeset(retro, %{}, nil, nil)
     render(conn, "edit.html", pair_retro: retro, changeset: changeset, projects: projects)
   end
   def edit(conn, _params) do
@@ -87,8 +86,7 @@ defmodule Pairmotron.PairRetroController do
     project_id = Map.get(pair_retro_params, "project_id") || (pair_retro.project && pair_retro.project.id) || 0
     project = Repo.get(Project, project_id)
 
-    earliest_pair_date = Pairmotron.Calendar.first_date_of_week(pair.year, pair.week)
-    changeset = PairRetro.update_changeset(pair_retro, pair_retro_params, earliest_pair_date, project, pair)
+    changeset = PairRetro.update_changeset(pair_retro, pair_retro_params, project, pair)
 
     case Repo.update(changeset) do
       {:ok, pair_retro} ->

--- a/web/controllers/pair_retro_controller.ex
+++ b/web/controllers/pair_retro_controller.ex
@@ -83,8 +83,7 @@ defmodule Pairmotron.PairRetroController do
     pair_retro = conn.assigns.pair_retro |> Repo.preload([:pair, :project])
     pair = pair_retro.pair
 
-    project_id = Map.get(pair_retro_params, "project_id") || (pair_retro.project && pair_retro.project.id) || 0
-    project = Repo.get(Project, project_id)
+    project = project_from_params_or_pair_retro(pair_retro_params, pair_retro)
 
     changeset = PairRetro.update_changeset(pair_retro, pair_retro_params, pair, project)
 
@@ -102,6 +101,11 @@ defmodule Pairmotron.PairRetroController do
     redirect_not_authorized(conn, pair_retro_path(conn, :index))
   end
 
+  defp project_from_params_or_pair_retro(params, pair_retro) do
+    id = Map.get(params, "project_id") || (pair_retro.project && pair_retro.project.id) || 0
+    Repo.get(Project, id)
+  end
+
   def delete(conn = @authorized_conn, _params) do
       Repo.delete!(conn.assigns.pair_retro)
 
@@ -111,14 +115,6 @@ defmodule Pairmotron.PairRetroController do
   end
   def delete(conn, _params) do
     redirect_not_authorized(conn, pair_retro_path(conn, :index))
-  end
-
-  defp earliest_pair_date_from_params(params) do
-    pair_id = parameter_as_integer(params, "pair_id")
-    case Repo.get(Pairmotron.Pair, pair_id) do
-      nil -> nil
-      pair -> Pairmotron.Calendar.first_date_of_week(pair.year, pair.week)
-    end
   end
 
   defp redirect_and_flash_error(conn, message) do

--- a/web/models/pair.ex
+++ b/web/models/pair.ex
@@ -28,16 +28,8 @@ defmodule Pairmotron.Pair do
   """
   def pair_with_users(pair_id) do
     from pair in Pairmotron.Pair,
-    join: users in assoc(pair, :users),
+    left_join: users in assoc(pair, :users),
     where: pair.id == ^pair_id,
     preload: [users: users]
-  end
-
-  def pair_with_users_and_group(pair_id) do
-    from pair in Pairmotron.Pair,
-    left_join: users in assoc(pair, :users),
-    left_join: group in assoc(pair, :group),
-    where: pair.id == ^pair_id,
-    preload: [users: users, group: group]
   end
 end

--- a/web/models/pair.ex
+++ b/web/models/pair.ex
@@ -26,8 +26,6 @@ defmodule Pairmotron.Pair do
   Ecto query that returns a pair with its :users association prelodaded.
   Performs a single database call.
   """
-  def pair_with_users(pair_id) when is_binary(pair_id), do:
-    Integer.parse(pair_id) |> elem(0) |> pair_with_users
   def pair_with_users(pair_id) do
     from pair in Pairmotron.Pair,
     join: users in assoc(pair, :users),

--- a/web/models/pair.ex
+++ b/web/models/pair.ex
@@ -34,4 +34,12 @@ defmodule Pairmotron.Pair do
     where: pair.id == ^pair_id,
     preload: [users: users]
   end
+
+  def pair_with_users_and_group(pair_id) do
+    from pair in Pairmotron.Pair,
+    left_join: users in assoc(pair, :users),
+    left_join: group in assoc(pair, :group),
+    where: pair.id == ^pair_id,
+    preload: [users: users, group: group]
+  end
 end

--- a/web/models/pair_retro.ex
+++ b/web/models/pair_retro.ex
@@ -27,7 +27,7 @@ defmodule Pairmotron.PairRetro do
   Validates that the selected project is associated with the group tht is
   associated with the pair.
   """
-  def changeset(struct, params \\ %{}, project, pair) do
+  def changeset(struct, params \\ %{}, pair, project) do
     struct
     |> cast(params, @required_fields, @optional_fields)
     |> foreign_key_constraint(:user_id)
@@ -52,7 +52,7 @@ defmodule Pairmotron.PairRetro do
   The update changeset does not allow the user to change the user or pair
   associated with the pair_retro.
   """
-  def update_changeset(struct, params \\ %{}, project, pair) do
+  def update_changeset(struct, params \\ %{}, pair, project) do
     struct
     |> cast(params, @required_update_fields, @optional_fields)
     |> foreign_key_constraint(:project_id)

--- a/web/models/pair_retro.ex
+++ b/web/models/pair_retro.ex
@@ -61,14 +61,11 @@ defmodule Pairmotron.PairRetro do
     |> validate_project_is_for_group(:project_id, project, pair)
   end
 
+  defp validate_date_is_not_before_pair(changeset, _, nil), do: changeset
   defp validate_date_is_not_before_pair(changeset, field, pair) do
-    pair_start_date = cond do
-      is_nil(pair) -> nil
-      true -> Pairmotron.Calendar.first_date_of_week(pair.year, pair.week)
-    end
+    pair_start_date = Pairmotron.Calendar.first_date_of_week(pair.year, pair.week)
     validate_change changeset, field, fn field, field_date ->
       cond do
-        is_nil(pair_start_date) -> []
         Timex.before?(Ecto.Date.to_erl(field_date), pair_start_date) ->
           [{field, "cannot be before the week of the pair"}]
         true -> []

--- a/web/models/pair_retro.ex
+++ b/web/models/pair_retro.ex
@@ -52,12 +52,13 @@ defmodule Pairmotron.PairRetro do
   The update changeset does not allow the user to change the user or pair
   associated with the pair_retro.
   """
-  def update_changeset(struct, params \\ %{}, pair_start_date) do
+  def update_changeset(struct, params \\ %{}, pair_start_date, project, pair) do
     struct
     |> cast(params, @required_update_fields, @optional_fields)
     |> foreign_key_constraint(:project_id)
     |> validate_field_is_not_before_date(:pair_date, pair_start_date)
     |> validate_field_is_not_in_future(:pair_date)
+    |> validate_project_is_for_group(:project_id, project, pair)
   end
 
   defp validate_field_is_not_before_date(changeset, field, pair_start_date) do

--- a/web/models/project.ex
+++ b/web/models/project.ex
@@ -68,4 +68,10 @@ defmodule Pairmotron.Project do
     join: u in assoc(group, :users),
     where: u.id == ^user.id
   end
+
+  def projects_for_group(group = %Pairmotron.Group{}), do: projects_for_group(group.id)
+  def projects_for_group(group_id) do
+    from project in Pairmotron.Project,
+    where: project.group_id == ^group_id
+  end
 end

--- a/web/templates/pair_retro/edit.html.eex
+++ b/web/templates/pair_retro/edit.html.eex
@@ -2,6 +2,6 @@
 
 <%= render "form.html", changeset: @changeset,
                         action: pair_retro_path(@conn, :update, @pair_retro),
-                        projects: projects_for_select(@conn) %>
+                        projects: projects_as_select(@projects) %>
 
 <%= link "Back", to: pair_retro_path(@conn, :index) %>

--- a/web/templates/pair_retro/new.html.eex
+++ b/web/templates/pair_retro/new.html.eex
@@ -2,6 +2,6 @@
 
 <%= render "form.html", changeset: @changeset,
                         action: pair_retro_path(@conn, :create),
-                        projects: projects_for_select(@conn) %>
+                        projects: projects_as_select(@projects) %>
 
 <%= link "Back", to: pair_retro_path(@conn, :index) %>

--- a/web/views/pair_retro_view.ex
+++ b/web/views/pair_retro_view.ex
@@ -7,13 +7,9 @@ defmodule Pairmotron.PairRetroView do
   def format_project(nil), do: "(none)"
   def format_project(%Pairmotron.Project{name: name}), do: name
 
-  def projects_for_select(conn) do
-    case conn.assigns[:projects] do
-      nil -> []
-      projects ->
-        projects
-        |> Enum.map(&["#{&1.name}": &1.id])
-        |> List.flatten
-    end
+  def projects_as_select(projects) do
+    projects
+    |> Enum.map(&["#{&1.name}": &1.id])
+    |> List.flatten
   end
 end


### PR DESCRIPTION
The PairRetro :new and :edit actions were assigning the projects used
for the dropdown to the conn rather than simply passing through the
projects to the view.

This also fixes a bug where if any errors occurred creating or updating
a PairRetro, the projects dropdown would not populate.

Refactor PairRetroController and the PairRetro model.
  - Add pair and project parameters to the changesets.
  - Remove earliest_pair_date paramter from changeset (since this information is on the pair that is now passed in).
  - Form for retros now only lists projects that are associated with the retro through the retro's pair's group.

Closes #58

Closes #84 

Further Issues
- [x] Disallow :edit and :update actions if the user is no longer in the group associated with the retro's pair. Also make the edit button the PairRetro :index not appear for retros where this is the case.