### PR TITLE
Update Timex to 3.1.13

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule Pairmotron.Mixfile do
      {:phoenix_live_reload, "~> 1.0", only: :dev},
      {:gettext, "~> 0.11"},
      {:cowboy, "~> 1.0"},
-     {:timex, github: "bitwalker/timex", ref: "6e52085c9b3ec6ef01261b95d6bf91629985617b"},
+     {:timex, "~> 3.1.13"},
      {:mix_test_watch, "~> 0.2", only: :dev},
      {:comeonin, "~> 2.6"},
      {:ex_machina, "~> 1.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -41,7 +41,7 @@
   "scrivener": {:hex, :scrivener, "2.2.1", "5a84cdfc042e3c318a03f965d8197b8294676a8fff7c4a29e482a90c467ebf19", [:mix], []},
   "scrivener_ecto": {:hex, :scrivener_ecto, "1.0.3", "35144d4b4f89a664eb291844e0f3954fe13d92c237f440d9a6562515cd6d44d2", [:mix], [{:ecto, "~> 2.0", [hex: :ecto, optional: false]}, {:postgrex, "~> 0.11.0 or ~> 0.12.0", [hex: :postgrex, optional: true]}, {:scrivener, "~> 2.0", [hex: :scrivener, optional: false]}]},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:rebar, :make], []},
-  "timex": {:git, "https://github.com/bitwalker/timex.git", "6e52085c9b3ec6ef01261b95d6bf91629985617b", [ref: "6e52085c9b3ec6ef01261b95d6bf91629985617b"]},
+  "timex": {:hex, :timex, "3.1.13", "48b33162e3ec33e9a08fb5f98e3f3c19c3e328dded3156096c1969b77d33eef0", [:mix], [{:combine, "~> 0.7", [hex: :combine, optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, optional: false]}]},
   "tzdata": {:hex, :tzdata, "0.5.10", "087e8dfe8c0283473115ad8ca6974b898ecb55ca5c725427a142a79593391e90", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, optional: false]}]},
   "uuid": {:hex, :uuid, "1.1.5", "96cb36d86ee82f912efea4d50464a5df606bf3f1163d6bdbb302d98474969369", [:mix], []},
   "xain": {:hex, :xain, "0.6.0", "5b61cfe3ffc17904759ee30a699f9e0b1aefd943e996ee4cafea76e5b2f59e3a", [:mix], []}}


### PR DESCRIPTION
The Timex dependency was left pointing at a github branch as a fix we made to Timex wasn't yet released. This PR simply updates that dependency to the latest version.