### PR TITLE
Fix Ecto.Query.CastError when no project is selected for a retrospective

### DIFF
--- a/test/controllers/pair_retro_controller_test.exs
+++ b/test/controllers/pair_retro_controller_test.exs
@@ -104,6 +104,19 @@ defmodule Pairmotron.PairRetroControllerTest do
       assert Repo.get_by(PairRetro, attrs)
     end
 
+    test 'creates retro if project_id param is "" (no project selected)', %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{owner: user, users: [user]})
+      pair = insert(:pair, %{group: group, users: [user]})
+
+      attrs = Map.merge(@valid_attrs, %{project_id: "",
+                                        pair_id: Integer.to_string(pair.id),
+                                        user_id: Integer.to_string(user.id)})
+
+      conn = post conn, pair_retro_path(conn, :create), pair_retro: attrs
+      assert redirected_to(conn) == pair_retro_path(conn, :index)
+      assert Repo.get_by(PairRetro, %{pair_id: pair.id, user_id: user.id})
+    end
+
     test "fails with a pair_date before the pair's week", %{conn: conn, logged_in_user: user} do
       group = insert(:group, %{owner: user, users: [user]})
       pair = insert(:pair, %{group: group, users: [user], year: 2016, week: 1})

--- a/web/controllers/pair_retro_controller.ex
+++ b/web/controllers/pair_retro_controller.ex
@@ -50,8 +50,7 @@ defmodule Pairmotron.PairRetroController do
         implicit_params = %{"user_id" => conn.assigns.current_user.id}
         final_params = pair_retro_params |> Map.merge(implicit_params)
 
-        project_id = Map.get(final_params, "project_id", 0)
-        project = Repo.get(Project, project_id)
+        project = project_from_params(final_params)
 
         changeset = PairRetro.changeset(%PairRetro{}, final_params, pair, project)
         case Repo.insert(changeset) do
@@ -63,6 +62,15 @@ defmodule Pairmotron.PairRetroController do
             projects = pair.group_id |> Project.projects_for_group |> Repo.all
             render(conn, "new.html", changeset: changeset, projects: projects)
         end
+    end
+  end
+
+  @spec project_from_params(map()) :: Types.project | nil
+  defp project_from_params(params) do
+    case Map.get(params, "project_id") do
+      nil -> nil
+      "" -> nil
+      project_id -> Repo.get(Project, project_id)
     end
   end
 

--- a/web/models/pair_retro.ex
+++ b/web/models/pair_retro.ex
@@ -101,11 +101,11 @@ defmodule Pairmotron.PairRetro do
   end
 
   @spec validate_project_is_for_group(%Ecto.Changeset{}, atom(), Types.pair, Types.project) :: %Ecto.Changeset{}
+  defp validate_project_is_for_group(changeset, _, nil, _), do: changeset
+  defp validate_project_is_for_group(changeset, _, _, nil), do: changeset
   defp validate_project_is_for_group(changeset, field, pair, project) do
     validate_change changeset, field, fn field, project_id ->
       cond do
-        is_nil(project) -> []
-        is_nil(pair) -> []
         pair.group_id != project.group_id ->
           [{field, "Must belong to the pair's group"}]
         project.id != project_id ->


### PR DESCRIPTION
The PairRetroController :create action wasn't properly handling a pair_id of "", which is what the form returns when the default option of the project "(none)" is selected. It now handles this properly.