### PR TITLE
Use shuffle in mixer

### DIFF
--- a/lib/pairmotron/mixer.ex
+++ b/lib/pairmotron/mixer.ex
@@ -1,12 +1,6 @@
 defmodule Pairmotron.Mixer do
 
-  def mixify(things, week \\ 1)
-  def mixify([], _week), do: []
-  def mixify(things, week) do
-    single = things
-      |> Enum.at(rem(week, length(things)))
-    remainder = things
-      |> List.delete(single)
-    [single | mixify(remainder, week)]
+  def mixify(things) do
+    things |> Enum.shuffle
   end
 end

--- a/lib/pairmotron/mixer.ex
+++ b/lib/pairmotron/mixer.ex
@@ -1,6 +1,13 @@
 defmodule Pairmotron.Mixer do
+  @moduledoc """
+  Mixes a provided list
+  """
 
-  def mixify(things) do
-    things |> Enum.shuffle
+  @doc """
+  Shuffles or applies the provided function to the provided list
+  """
+  @spec mixify(List.t, Fun.t) :: List.t
+  def mixify(things, function \\ &Enum.shuffle/1) do
+    things |> function.()
   end
 end

--- a/lib/pairmotron/mixer.ex
+++ b/lib/pairmotron/mixer.ex
@@ -6,7 +6,7 @@ defmodule Pairmotron.Mixer do
   @doc """
   Shuffles or applies the provided function to the provided list
   """
-  @spec mixify(List.t, Fun.t) :: List.t
+  @spec mixify(List.t, (List.t -> List.t)) :: List.t
   def mixify(things, function \\ &Enum.shuffle/1) do
     things |> function.()
   end

--- a/lib/pairmotron/pair_maker.ex
+++ b/lib/pairmotron/pair_maker.ex
@@ -66,7 +66,7 @@ defmodule Pairmotron.PairMaker do
       |> Enum.filter(&(Enum.empty?(&1.pair_retros)))
 
     results = determination.available_users
-      |> Mixer.mixify(week)
+      |> Mixer.mixify
       |> Pairer.generate_pairs(pairs)
 
     Ecto.Multi.new

--- a/test/lib/mixer_test.exs
+++ b/test/lib/mixer_test.exs
@@ -27,11 +27,6 @@ defmodule Pairmotron.MixerTest do
       results = Mixer.mixify([1, 2, 3, 4, 5, 6, 7, 8])
       assert Enum.sort(results) == [1, 2, 3, 4, 5, 6, 7, 8]
     end
-
-    test "returns a list not in the same order" do
-      results = Mixer.mixify([1, 2, 3, 4, 5, 6, 7, 8])
-      refute results == [1, 2, 3, 4, 5, 6, 7, 8]
-    end
   end
 
   describe "mixify/2 with a custom shuffle function" do

--- a/test/lib/mixer_test.exs
+++ b/test/lib/mixer_test.exs
@@ -3,21 +3,34 @@ defmodule Pairmotron.MixerTest do
 
   alias Pairmotron.Mixer
 
-  describe ".mixify" do
-    test "empty list returns an empty list" do
+  describe "mixify/1 with an empty list" do
+    test "returns an empty list" do
       assert Mixer.mixify([]) == []
     end
+  end
 
-    test "list of one returns same list" do
+  describe "mixify/1 with a list of one" do
+    test "returns the same list" do
       assert Mixer.mixify([1]) == [1]
     end
+  end
 
-    test "list of two things with the same seed returns a predictable list" do
-      assert Mixer.mixify([1, 2]) == [2, 1]
+  describe "mixify/1 with a list of two" do
+    test "returns a list containing both things" do
+      results = Mixer.mixify([1, 2])
+      assert Enum.sort(results) == [1, 2]
+    end
+  end
+
+  describe "mixify/1 with a list of many" do
+    test "returns a list containing all things" do
+      results = Mixer.mixify([1, 2, 3, 4, 5, 6, 7, 8])
+      assert Enum.sort(results) == [1, 2, 3, 4, 5, 6, 7, 8]
     end
 
-    test "list of many things with the same seed returns a predictable list" do
-      assert Mixer.mixify([1, 2, 3, 4, 5, 6, 7, 8], 3) == [4, 5, 6, 7, 8, 1, 3, 2]
+    test "returns a list not in the same order" do
+      results = Mixer.mixify([1, 2, 3, 4, 5, 6, 7, 8])
+      refute results == [1, 2, 3, 4, 5, 6, 7, 8]
     end
   end
 end

--- a/test/lib/mixer_test.exs
+++ b/test/lib/mixer_test.exs
@@ -33,4 +33,11 @@ defmodule Pairmotron.MixerTest do
       refute results == [1, 2, 3, 4, 5, 6, 7, 8]
     end
   end
+
+  describe "mixify/2 with a custom shuffle function" do
+    test "applies the function" do
+      results = Mixer.mixify([1, 2, 3, 4, 5], &Enum.reverse/1)
+      assert results == [5, 4, 3, 2, 1]
+    end
+  end
 end


### PR DESCRIPTION
Since pairs are no longer deleted unless necessary during repairifying,
  we can use the built in shuffle and accept completely random results.

@mbramson I think the chance that shuffling an 8 element list results in the original order to be sufficiently rare. We can increase this or figure out a better test if you disagree.