### PR TITLE
Fix error while removing multiple pairs during a repairify

### DIFF
--- a/lib/pairmotron/pair_maker.ex
+++ b/lib/pairmotron/pair_maker.ex
@@ -77,9 +77,13 @@ defmodule Pairmotron.PairMaker do
   end
 
   defp remove_dead_pairs(multi, dead_pairs) do
+    # The atom name in multi functions needs to be unique to the multi.
+    # We are using the index to avoid creating enough new atoms to reach the atom-limit.
     dead_pairs
-      |> Enum.reduce(multi, fn(pair, acc) ->
-          acc |> Ecto.Multi.delete(:remove_dead_pairs, pair)
+      |> Enum.with_index
+      |> Enum.reduce(multi, fn({pair, index}, acc) ->
+          atom = String.to_atom("remove_dead_pair_#{index}")
+          acc |> Ecto.Multi.delete(atom, pair)
       end)
   end
 

--- a/test/lib/pair_maker_test.exs
+++ b/test/lib/pair_maker_test.exs
@@ -90,6 +90,21 @@ defmodule Pairmotron.PairMakerTest do
       group = insert(:group, %{owner: user, users: [user, insert(:user), insert(:user), insert(:user), insert(:user), insert(:user), insert(:user)]})
       PairMaker.generate_pairs(2017, 1, group.id)
     end
+
+    test "can remove several no longer valid pairs" do
+      user = insert(:user)
+      user2 = insert(:user)
+      user3 = insert(:user)
+      user4 = insert(:user)
+      group = insert(:group, %{owner: user, users: [user, user2, user3, user4]})
+      PairMaker.generate_pairs(2017, 1, group.id)
+      user |> Ecto.Changeset.change(active: false) |> Repo.update
+      user2 |> Ecto.Changeset.change(active: false) |> Repo.update
+      user3 |> Ecto.Changeset.change(active: false) |> Repo.update
+      user4 |> Ecto.Changeset.change(active: false) |> Repo.update
+      PairMaker.generate_pairs(2017, 1, group.id)
+      assert Repo.all(UserPair) == []
+    end
   end
 
   describe "fetch_or_gen/3" do


### PR DESCRIPTION
@mbramson found this issue during the mixify -> shuffle change. Same lesson as the previous time.