### PR TITLE
Update generate_password function name

### DIFF
--- a/test/models/user_test.exs
+++ b/test/models/user_test.exs
@@ -6,14 +6,200 @@ defmodule Pairmotron.UserTest do
   @valid_attrs %{email: "some content", name: "some content"}
   @invalid_attrs %{}
 
-  test "changeset with valid attributes" do
-    changeset = User.changeset(%User{}, @valid_attrs)
-    assert changeset.valid?
+  describe "changeset/2" do
+    test "with valid attributes is valid" do
+      changeset = User.changeset(%User{}, @valid_attrs)
+      assert changeset.valid?
+    end
+
+    test "with valid attributes with password change updates the password_hash" do
+      attrs = Map.merge(@valid_attrs, %{password: "password", password_confirmation: "password"})
+      changeset = User.changeset(%User{}, attrs)
+      assert Map.has_key?(changeset.changes, :password_hash)
+      assert changeset.valid?
+    end
+
+    test "with valid attributes with no password change does not update password_hash" do
+      changeset = User.changeset(%User{}, @valid_attrs)
+      refute Map.has_key?(changeset.changes, :password_hash)
+      assert changeset.valid?
+    end
+
+    test "with invalid attributes with password change does not update password_hash" do
+      attrs = Map.merge(@invalid_attrs, %{password: "password", password_confirmation: "password"})
+      changeset = User.changeset(%User{}, attrs)
+      refute Map.has_key?(changeset.changes, :password_hash)
+      refute changeset.valid?
+    end
+
+    test "is invalid and does not update password_hash if password and password_confirmation do not match" do
+      attrs = Map.merge(@valid_attrs, %{password: "password", password_confirmation: "not_password"})
+      changeset = User.changeset(%User{}, attrs)
+      refute Map.has_key?(changeset.changes, :password_hash)
+      refute changeset.valid?
+    end
+
+    test "is invalid without name" do
+      attrs = Map.delete(@valid_attrs, :name)
+      changeset = User.changeset(%User{}, attrs)
+      refute changeset.valid?
+    end
+
+    test "is invalid without email" do
+      attrs = Map.delete(@valid_attrs, :email)
+      changeset = User.changeset(%User{}, attrs)
+      refute changeset.valid?
+    end
+
+    test "can alter the is_admin field" do
+      attrs = Map.merge(@valid_attrs, %{is_admin: true})
+      changeset = User.changeset(%User{}, attrs)
+      assert Map.has_key?(changeset.changes, :is_admin)
+      assert changeset.valid?
+    end
+
+    test "can alter the active field" do
+      attrs = Map.merge(@valid_attrs, %{active: true})
+      changeset = User.changeset(%User{}, attrs)
+      assert Map.has_key?(changeset.changes, :active)
+      assert changeset.valid?
+    end
+
+    test "with invalid attributes is invalid" do
+      changeset = User.changeset(%User{}, @invalid_attrs)
+      refute changeset.valid?
+    end
   end
 
-  test "changeset with invalid attributes" do
-    changeset = User.changeset(%User{}, @invalid_attrs)
-    refute changeset.valid?
+  @valid_reg_attrs %{email: "some content", name: "some content", password: "password", password_confirmation: "password"}
+
+  describe "registration_changeset/2" do
+    test "with valid attributes is valid" do
+      changeset = User.registration_changeset(%User{}, @valid_reg_attrs)
+      assert changeset.valid?
+    end
+
+    test "with valid attributes with password change updates the password_hash" do
+      attrs = Map.merge(@valid_reg_attrs, %{password: "password"})
+      changeset = User.registration_changeset(%User{}, attrs)
+      assert Map.has_key?(changeset.changes, :password_hash)
+      assert changeset.valid?
+    end
+
+    test "with valid attributes with no password change does not update password_hash and is invalid" do
+      changeset = User.registration_changeset(%User{}, @valid_attrs)
+      refute Map.has_key?(changeset.changes, :password_hash)
+      refute changeset.valid?
+    end
+
+    test "with invalid attributes with password change does not update password_hash" do
+      attrs = Map.merge(@invalid_attrs, %{password: "password"})
+      changeset = User.registration_changeset(%User{}, attrs)
+      refute Map.has_key?(changeset.changes, :password_hash)
+      refute changeset.valid?
+    end
+
+    test "is invalid and does not update password_hash if password and password_confirmation do not match" do
+      attrs = Map.merge(@valid_reg_attrs, %{password: "password", password_confirmation: "not_password"})
+      changeset = User.registration_changeset(%User{}, attrs)
+      refute Map.has_key?(changeset.changes, :password_hash)
+      refute changeset.valid?
+    end
+
+    test "is invalid without name" do
+      attrs = Map.delete(@valid_reg_attrs, :name)
+      changeset = User.registration_changeset(%User{}, attrs)
+      refute changeset.valid?
+    end
+
+    test "is invalid without email" do
+      attrs = Map.delete(@valid_reg_attrs, :email)
+      changeset = User.registration_changeset(%User{}, attrs)
+      refute changeset.valid?
+    end
+
+    test "cannot alter the is_admin field" do
+      attrs = Map.merge(@valid_reg_attrs, %{is_admin: true})
+      changeset = User.registration_changeset(%User{}, attrs)
+      refute Map.has_key?(changeset.changes, :is_admin)
+      assert changeset.valid?
+    end
+
+    test "can alter the active field" do
+      attrs = Map.merge(@valid_reg_attrs, %{active: true})
+      changeset = User.registration_changeset(%User{}, attrs)
+      assert Map.has_key?(changeset.changes, :active)
+      assert changeset.valid?
+    end
+
+    test "with invalid attributes is invalid" do
+      changeset = User.registration_changeset(%User{}, @invalid_attrs)
+      refute changeset.valid?
+    end
   end
 
+  describe "profile_changeset/2" do
+    test "with valid attributes is valid" do
+      changeset = User.profile_changeset(%User{}, @valid_attrs)
+      assert changeset.valid?
+    end
+
+    test "with valid attributes with password change updates the password_hash" do
+      attrs = Map.merge(@valid_attrs, %{password: "password"})
+      changeset = User.profile_changeset(%User{}, attrs)
+      assert Map.has_key?(changeset.changes, :password_hash)
+      assert changeset.valid?
+    end
+
+    test "with valid attributes with no password change does not update password_hash" do
+      changeset = User.profile_changeset(%User{}, @valid_attrs)
+      refute Map.has_key?(changeset.changes, :password_hash)
+      assert changeset.valid?
+    end
+
+    test "with invalid attributes with password change does not update password_hash" do
+      attrs = Map.merge(@invalid_attrs, %{password: "password"})
+      changeset = User.profile_changeset(%User{}, attrs)
+      refute Map.has_key?(changeset.changes, :password_hash)
+      refute changeset.valid?
+    end
+
+    test "is invalid and does not update password_hash if password and password_confirmation do not match" do
+      attrs = Map.merge(@valid_attrs, %{password: "password", password_confirmation: "not_password"})
+      changeset = User.profile_changeset(%User{}, attrs)
+      refute Map.has_key?(changeset.changes, :password_hash)
+      refute changeset.valid?
+    end
+
+    test "is invalid without name" do
+      attrs = Map.delete(@valid_attrs, :name)
+      changeset = User.profile_changeset(%User{}, attrs)
+      refute changeset.valid?
+    end
+
+    test "is invalid without email" do
+      attrs = Map.delete(@valid_attrs, :email)
+      changeset = User.profile_changeset(%User{}, attrs)
+      refute changeset.valid?
+    end
+
+    test "cannot alter the is_admin field" do
+      attrs = Map.merge(@valid_attrs, %{is_admin: true})
+      changeset = User.profile_changeset(%User{}, attrs)
+      refute Map.has_key?(changeset.changes, :is_admin)
+      assert changeset.valid?
+    end
+
+    test "can alter the active field" do
+      attrs = Map.merge(@valid_attrs, %{active: true})
+      changeset = User.profile_changeset(%User{}, attrs)
+      assert Map.has_key?(changeset.changes, :active)
+      assert changeset.valid?
+    end
+
+    test "with invalid attributes is invalid" do
+      changeset = User.profile_changeset(%User{}, @invalid_attrs)
+      refute changeset.valid?
+    end
+  end
 end

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -72,11 +72,14 @@ defmodule Pairmotron.User do
     |> validate_length(:password, min: @minimum_password_length)
     |> validate_length(:password_confirmation, min: @minimum_password_length)
     |> validate_confirmation(:password)
-    |> generate_password
+    |> hash_password_if_changed_and_valid
   end
 
-  @spec generate_password(%Ecto.Changeset{}) :: %Ecto.Changeset{}
-  defp generate_password(changeset) do
+  # Hashes the contents of the :password field and inserts the results into the
+  # :password_hash field. Only hashes and inserts if the password was changed
+  # and the changeset is valid.
+  @spec hash_password_if_changed_and_valid(%Ecto.Changeset{}) :: %Ecto.Changeset{}
+  defp hash_password_if_changed_and_valid(changeset) do
     case changeset do
       %Ecto.Changeset{valid?: true, changes: %{password: pass}} ->
         put_change(changeset, :password_hash, Comeonin.Bcrypt.hashpwsalt(pass))

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -37,6 +37,10 @@ defmodule Pairmotron.User do
 
   @doc """
   Builds a changeset based on the `struct` and `params`.
+
+  Meant to only be used by administrators through an administrator interface as
+  this changeset allows all properties to be changed including the is_admin
+  field.
   """
   @spec changeset(map() | %Ecto.Changeset{}, map()) :: %Ecto.Changeset{}
   def changeset(struct, params \\ %{}) do
@@ -48,6 +52,13 @@ defmodule Pairmotron.User do
   @required_registration_params ~w(name email password password_confirmation)
   @optional_registration_params ~w(active)
 
+  @doc """
+  Builds a changeset based on the `struct` and `params`.
+
+  Used by the RegistrationController. Requires a password and
+  password_confirmation to be specified and does not allow the is_admin field
+  to be altered.
+  """
   @spec registration_changeset(map() | %Ecto.Changeset{}, map()) :: %Ecto.Changeset{}
   def registration_changeset(struct, params \\ %{}) do
     struct
@@ -58,6 +69,14 @@ defmodule Pairmotron.User do
   @required_profile_params ~w(name email)
   @optional_profile_params ~w(active password password_confirmation)
 
+  @doc """
+  Builds a changeset based on the `struct` and `params`.
+
+  Used by the ProfileController. Does not require a password so that users can
+  modify their other attributes without being forced to change their password.
+  However, users can update their password using this changeset if they wish.
+  Does not allow the modification of the is_admin field.
+  """
   @spec profile_changeset(map() | %Ecto.Changeset{}, map()) :: %Ecto.Changeset{}
   def profile_changeset(struct, params \\ %{}) do
     struct


### PR DESCRIPTION
The function name "generate password" implied that it always inserted
the hashed password into the changeset, when in fact it only inserts it
if the changeset is valid and the password has changed. Changed the name
to better reflect this and improve readability.