### PR TITLE
Change pair_retro reflection to be :text type

### DIFF
--- a/priv/repo/migrations/20170310142420_extend_pair_retro_reflection.exs
+++ b/priv/repo/migrations/20170310142420_extend_pair_retro_reflection.exs
@@ -1,10 +1,15 @@
 defmodule Pairmotron.Repo.Migrations.ExtendPairRetroReflection do
   use Ecto.Migration
 
-  def change do
+  def up do
     alter table(:pair_retros) do
       modify :reflection, :text
     end
+  end
 
+  def down do
+    alter table(:pair_retros) do
+      modify :reflection, :string
+    end
   end
 end

--- a/priv/repo/migrations/20170310142420_extend_pair_retro_reflection.exs
+++ b/priv/repo/migrations/20170310142420_extend_pair_retro_reflection.exs
@@ -1,0 +1,10 @@
+defmodule Pairmotron.Repo.Migrations.ExtendPairRetroReflection do
+  use Ecto.Migration
+
+  def change do
+    alter table(:pair_retros) do
+      modify :reflection, :text
+    end
+
+  end
+end

--- a/test/controllers/pair_retro_controller_test.exs
+++ b/test/controllers/pair_retro_controller_test.exs
@@ -104,6 +104,20 @@ defmodule Pairmotron.PairRetroControllerTest do
       assert Repo.get_by(PairRetro, attrs)
     end
 
+    test "creates retro when reflection is large", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{owner: user, users: [user]})
+      pair = insert(:pair, %{group: group, users: [user]})
+
+      attrs = Map.merge(@valid_attrs, %{pair_id: Integer.to_string(pair.id),
+                                        user_id: Integer.to_string(user.id),
+                                        reflection: String.duplicate("a", 256)
+                                      })
+
+      conn = post conn, pair_retro_path(conn, :create), pair_retro: attrs
+      assert redirected_to(conn) == pair_retro_path(conn, :index)
+      assert Repo.get_by(PairRetro, attrs)
+    end
+
     test 'creates retro if project_id param is "" (no project selected)', %{conn: conn, logged_in_user: user} do
       group = insert(:group, %{owner: user, users: [user]})
       pair = insert(:pair, %{group: group, users: [user]})


### PR DESCRIPTION
@mbramson Noticed that the retro reflection text was limited. Found via an error when I tried to write up a longer retro. The default for `:string` type is `varchar(255)`. This modifies pair_retros to use a `:text` type in Postgres, so it is now unlimited.