### PR TITLE
Add ability to delete group invitations

### DIFF
--- a/lib/pairmotron/invite_delete_helper.ex
+++ b/lib/pairmotron/invite_delete_helper.ex
@@ -20,7 +20,7 @@ defmodule Pairmotron.InviteDeleteHelper do
       Repo.delete!(group_membership_request)
       conn
       |> put_flash(:info, "Group Invite deleted successfully.")
-      |> redirect(to: group_invitation_path(conn, :index, group_membership_request.group_id))
+      |> redirect(to: redirect_path)
     else
       redirect_and_flash_error(conn, "You cannot delete that group invitation", redirect_path)
     end

--- a/lib/pairmotron/invite_delete_helper.ex
+++ b/lib/pairmotron/invite_delete_helper.ex
@@ -1,0 +1,40 @@
+defmodule Pairmotron.InviteDeleteHelper do
+  @moduledoc """
+  Helper library used to reduce duplication between the :delete actions of the
+  UsersGroupMembershipRequestController and the GroupInvitationController.
+  """
+  use Pairmotron.Web, :controller
+
+  @doc """
+  Deletes an invitation and redirects to the proper path.
+
+  Created to reduce duplication between the :delete actions in the
+  UsersGroupMembershipRequestController and the GroupInvitationController,
+  since the logic is identical, except for the redirect path.
+  """
+  @spec delete_invite(Plug.Conn.t, Types.group_membership_request, binary()) :: Plug.Conn.t
+  def delete_invite(conn, group_membership_request, redirect_path) do
+    current_user = conn.assigns.current_user
+
+    if user_can_delete_invite(current_user, group_membership_request) do
+      Repo.delete!(group_membership_request)
+      conn
+      |> put_flash(:info, "Group Invite deleted successfully.")
+      |> redirect(to: group_invitation_path(conn, :index, group_membership_request.group_id))
+    else
+      redirect_and_flash_error(conn, "You cannot delete that group invitation", redirect_path)
+    end
+  end
+
+  @spec redirect_and_flash_error(%Plug.Conn{}, binary(), binary()) :: %Plug.Conn{}
+  defp redirect_and_flash_error(conn, message, redirect_path) do
+    conn
+    |> put_flash(:error, message)
+    |> redirect(to: redirect_path)
+  end
+
+  @spec user_can_delete_invite(Types.user, Types.group_membership_request) :: boolean()
+  defp user_can_delete_invite(user, group_membership_request) do
+    user.id in [group_membership_request.user_id, group_membership_request.group.owner_id]
+  end
+end

--- a/web/controllers/group_invitation_controller.ex
+++ b/web/controllers/group_invitation_controller.ex
@@ -118,6 +118,26 @@ defmodule Pairmotron.GroupInvitationController do
     end
   end
 
+  @spec delete(%Plug.Conn{}, map()) :: %Plug.Conn{}
+  def delete(conn, %{"id" => id}) do
+    group_membership_request = Repo.get!(GroupMembershipRequest, id) |> Repo.preload(:group)
+    current_user = conn.assigns.current_user
+
+    if user_can_delete_invite(current_user, group_membership_request) do
+      Repo.delete!(group_membership_request)
+      conn
+      |> put_flash(:info, "Group Invite deleted successfully.")
+      |> redirect(to: group_invitation_path(conn, :index, group_membership_request.group_id))
+    else
+      redirect_and_flash_error(conn, "You cannot delete that group invitation", group_membership_request.group_id)
+    end
+  end
+
+  @spec user_can_delete_invite(Types.user, Types.group_membership_request) :: boolean()
+  defp user_can_delete_invite(user, group_membership_request) do
+    user.id in [group_membership_request.user_id, group_membership_request.group.owner_id]
+  end
+
   @spec redirect_and_flash_error(%Plug.Conn{}, binary(), integer()) :: %Plug.Conn{}
   defp redirect_and_flash_error(conn, message, group_id) do
     conn

--- a/web/controllers/group_invitation_controller.ex
+++ b/web/controllers/group_invitation_controller.ex
@@ -14,6 +14,9 @@ defmodule Pairmotron.GroupInvitationController do
   The :update action accepts a user's  request to join a group. This invitation
   must have been created by that user. If this succeeds, the
   GroupMembershipRequest is deleted and that User is now part of this group.
+
+  The :delete action deletes an invitation and redirects to the group's list of
+  invitations.
   """
   use Pairmotron.Web, :controller
 
@@ -121,7 +124,7 @@ defmodule Pairmotron.GroupInvitationController do
 
   @spec delete(%Plug.Conn{}, map()) :: %Plug.Conn{}
   def delete(conn, %{"id" => id}) do
-    group_membership_request = Repo.get!(GroupMembershipRequest, id) |> Repo.preload(:group)
+    group_membership_request = GroupMembershipRequest |> Repo.get!(id) |> Repo.preload(:group)
     redirect_path = group_invitation_path(conn, :index, group_membership_request.group_id)
     InviteDeleteHelper.delete_invite(conn, group_membership_request, redirect_path)
   end

--- a/web/controllers/users_group_membership_request_controller.ex
+++ b/web/controllers/users_group_membership_request_controller.ex
@@ -13,10 +13,14 @@ defmodule Pairmotron.UsersGroupMembershipRequestController do
   must have been created by the group. If this succeeds, the
   GroupMembershipRequest is deleted, and the User is now a member of that
   group.
+
+  The :delete action deletes an invitation and redirects to the user's list of
+  invitations.
   """
   use Pairmotron.Web, :controller
 
   alias Pairmotron.{Group, GroupMembershipRequest, UserGroup}
+  alias Pairmotron.InviteDeleteHelper
   import Pairmotron.ControllerHelpers
 
   plug :load_resource, model: GroupMembershipRequest, only: [:update]
@@ -84,6 +88,13 @@ defmodule Pairmotron.UsersGroupMembershipRequestController do
             redirect_and_flash_error(conn, "Error adding user to group")
         end
     end
+  end
+
+  @spec delete(%Plug.Conn{}, map()) :: %Plug.Conn{}
+  def delete(conn, %{"id" => id}) do
+    group_membership_request = GroupMembershipRequest |> Repo.get!(id) |> Repo.preload(:group)
+    redirect_path = users_group_membership_request_path(conn, :index)
+    InviteDeleteHelper.delete_invite(conn, group_membership_request, redirect_path)
   end
 
   @spec user_is_in_group?(Types.user, group_id :: integer() | binary()) :: boolean()

--- a/web/router.ex
+++ b/web/router.ex
@@ -57,7 +57,7 @@ defmodule Pairmotron.Router do
     get "/groups/:id/pairs/:year/:week", GroupPairController, :show
     delete "/groups/:id/pairs/:year/:week", GroupPairController, :delete
     resources "/groups/:group_id/invitations", GroupInvitationController, only: [:index, :new, :create, :update, :delete]
-    resources "/invitations", UsersGroupMembershipRequestController, only: [:index, :create, :update]
+    resources "/invitations", UsersGroupMembershipRequestController, only: [:index, :create, :update, :delete]
     resources "/groups", GroupController
 
     get "/pair_retros/new/:pair_id", PairRetroController, :new

--- a/web/router.ex
+++ b/web/router.ex
@@ -56,7 +56,7 @@ defmodule Pairmotron.Router do
     get "/groups/:id/pairs", GroupPairController, :show
     get "/groups/:id/pairs/:year/:week", GroupPairController, :show
     delete "/groups/:id/pairs/:year/:week", GroupPairController, :delete
-    resources "/groups/:group_id/invitations", GroupInvitationController, only: [:index, :new, :create, :update]
+    resources "/groups/:group_id/invitations", GroupInvitationController, only: [:index, :new, :create, :update, :delete]
     resources "/invitations", UsersGroupMembershipRequestController, only: [:index, :create, :update]
     resources "/groups", GroupController
 

--- a/web/templates/group_invitation/index.html.eex
+++ b/web/templates/group_invitation/index.html.eex
@@ -5,6 +5,7 @@
     <tr>
       <th>User</th>
       <th>Status</th>
+      <th/>
     </tr>
   </thead>
   <tbody>
@@ -22,6 +23,11 @@
         <%= else %>
           <td>Awaiting Response</td>
         <%= end %>
+        <td>
+          <%= if @group.owner_id == @conn.assigns.current_user.id do %>
+          <%= link "Delete", to: group_invitation_path(@conn, :delete, group_membership_request.group_id, group_membership_request), method: :delete, class: "btn btn-danger" %>
+          <%= end %>
+        </td>
       </tr>
     <%= end %>
   </tbody>

--- a/web/templates/users_group_membership_request/index.html.eex
+++ b/web/templates/users_group_membership_request/index.html.eex
@@ -5,6 +5,7 @@
     <tr>
       <th>Group</th>
       <th>Status</th>
+      <th/>
     </tr>
   </thead>
   <tbody>
@@ -22,6 +23,9 @@
                   action: users_group_membership_request_path(@conn, :update, group_membership_request) %>
           </td>
         <%= end %>
+        <td>
+          <%= link "Decline", to: users_group_membership_request_path(@conn, :delete, group_membership_request), method: :delete, class: "btn btn-danger" %>
+        </td>
       </tr>
     <%= end %>
   </tbody>


### PR DESCRIPTION
Adds controller actions and links on the UI to be able to delete invitations if you are the owner of the group associated with the invitation or the user associated with the invitation.

Closes #102