### PR TITLE
Add UserGroupController allowing users to leave groups

### DIFF
--- a/test/controllers/user_group_controller_test.exs
+++ b/test/controllers/user_group_controller_test.exs
@@ -1,0 +1,56 @@
+defmodule Pairmotron.GroupInvitationControllerTest do
+  use Pairmotron.ConnCase
+
+  alias Pairmotron.UserGroup
+
+  test "redirects to sign-in when not logged in", %{conn: conn} do
+    group = insert(:group)
+    user_group = insert(:user_group, %{group: group})
+    conn = delete conn, user_group_path(conn, :delete, user_group)
+    assert redirected_to(conn) == session_path(conn, :new)
+  end
+
+  describe "using :delete while authenticated" do
+    setup do
+      login_user()
+    end
+
+    test "deletes user group if logged in user is associated", %{conn: conn, logged_in_user: user} do
+      group = insert(:group)
+      user_group = insert(:user_group, %{group: group, user: user})
+
+      conn = delete conn, user_group_path(conn, :delete, user_group)
+      assert redirected_to(conn) == profile_path(conn, :show)
+      refute Repo.get(UserGroup, user_group.id)
+    end
+
+    test "deletes user group if logged in user owns the associated group", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{owner: user})
+      user_group = insert(:user_group, %{group: group})
+
+      conn = delete conn, user_group_path(conn, :delete, user_group)
+      assert redirected_to(conn) == group_path(conn, :show, group)
+      refute Repo.get(UserGroup, user_group.id)
+    end
+
+    test "deletes user group and redirects to profile user is owner of group and the user on the user_group",
+      %{conn: conn, logged_in_user: user} do
+
+      group = insert(:group, %{owner: user})
+      user_group = insert(:user_group, %{group: group, user: user})
+
+      conn = delete conn, user_group_path(conn, :delete, user_group)
+      assert redirected_to(conn) == profile_path(conn, :show)
+      refute Repo.get(UserGroup, user_group.id)
+    end
+
+    test "fails if logged in user is not associated with user group", %{conn: conn} do
+      group = insert(:group)
+      user_group = insert(:user_group, %{group: group})
+
+      conn = delete conn, user_group_path(conn, :delete, user_group)
+      assert redirected_to(conn) == group_path(conn, :show, group)
+      assert Repo.get(UserGroup, user_group.id)
+    end
+  end
+end

--- a/test/controllers/user_group_controller_test.exs
+++ b/test/controllers/user_group_controller_test.exs
@@ -55,5 +55,24 @@ defmodule Pairmotron.GroupInvitationControllerTest do
       assert redirected_to(conn) == group_path(conn, :show, group)
       assert Repo.get(UserGroup, user_group.id)
     end
+
+    test "fails and redirects if user in route doesn't exist", %{conn: conn} do
+      group = insert(:group)
+      conn = delete conn, user_group_path(conn, :delete, group, 123)
+      assert redirected_to(conn) == pair_path(conn, :index)
+    end
+
+    test "fails and redirects if group in route doesn't exist", %{conn: conn} do
+      other_user = insert(:user)
+      conn = delete conn, user_group_path(conn, :delete, 123, other_user)
+      assert redirected_to(conn) == pair_path(conn, :index)
+    end
+
+    test "fails and redirects if specified user is not in group", %{conn: conn} do
+      group = insert(:group)
+      other_user = insert(:user)
+      conn = delete conn, user_group_path(conn, :delete, group, other_user)
+      assert redirected_to(conn) == pair_path(conn, :index)
+    end
   end
 end

--- a/test/controllers/user_group_controller_test.exs
+++ b/test/controllers/user_group_controller_test.exs
@@ -6,7 +6,7 @@ defmodule Pairmotron.UserGroupControllerTest do
   test "redirects to sign-in when not logged in", %{conn: conn} do
     group = insert(:group)
     other_user = insert(:user)
-    user_group = insert(:user_group, %{group: group, user: other_user})
+    insert(:user_group, %{group: group, user: other_user})
     conn = delete conn, user_group_path(conn, :delete, group, other_user)
     assert redirected_to(conn) == session_path(conn, :new)
   end

--- a/test/controllers/user_group_controller_test.exs
+++ b/test/controllers/user_group_controller_test.exs
@@ -1,4 +1,4 @@
-defmodule Pairmotron.GroupInvitationControllerTest do
+defmodule Pairmotron.UserGroupControllerTest do
   use Pairmotron.ConnCase
 
   alias Pairmotron.UserGroup

--- a/test/controllers/user_group_controller_test.exs
+++ b/test/controllers/user_group_controller_test.exs
@@ -5,8 +5,9 @@ defmodule Pairmotron.GroupInvitationControllerTest do
 
   test "redirects to sign-in when not logged in", %{conn: conn} do
     group = insert(:group)
-    user_group = insert(:user_group, %{group: group})
-    conn = delete conn, user_group_path(conn, :delete, user_group)
+    other_user = insert(:user)
+    user_group = insert(:user_group, %{group: group, user: other_user})
+    conn = delete conn, user_group_path(conn, :delete, group, other_user)
     assert redirected_to(conn) == session_path(conn, :new)
   end
 
@@ -19,16 +20,17 @@ defmodule Pairmotron.GroupInvitationControllerTest do
       group = insert(:group)
       user_group = insert(:user_group, %{group: group, user: user})
 
-      conn = delete conn, user_group_path(conn, :delete, user_group)
+      conn = delete conn, user_group_path(conn, :delete, group, user)
       assert redirected_to(conn) == profile_path(conn, :show)
       refute Repo.get(UserGroup, user_group.id)
     end
 
     test "deletes user group if logged in user owns the associated group", %{conn: conn, logged_in_user: user} do
       group = insert(:group, %{owner: user})
-      user_group = insert(:user_group, %{group: group})
+      other_user = insert(:user)
+      user_group = insert(:user_group, %{group: group, user: other_user})
 
-      conn = delete conn, user_group_path(conn, :delete, user_group)
+      conn = delete conn, user_group_path(conn, :delete, group, other_user)
       assert redirected_to(conn) == group_path(conn, :show, group)
       refute Repo.get(UserGroup, user_group.id)
     end
@@ -39,16 +41,17 @@ defmodule Pairmotron.GroupInvitationControllerTest do
       group = insert(:group, %{owner: user})
       user_group = insert(:user_group, %{group: group, user: user})
 
-      conn = delete conn, user_group_path(conn, :delete, user_group)
+      conn = delete conn, user_group_path(conn, :delete, group, user)
       assert redirected_to(conn) == profile_path(conn, :show)
       refute Repo.get(UserGroup, user_group.id)
     end
 
     test "fails if logged in user is not associated with user group", %{conn: conn} do
       group = insert(:group)
-      user_group = insert(:user_group, %{group: group})
+      other_user = insert(:user)
+      user_group = insert(:user_group, %{group: group, user: other_user})
 
-      conn = delete conn, user_group_path(conn, :delete, user_group)
+      conn = delete conn, user_group_path(conn, :delete, group, other_user)
       assert redirected_to(conn) == group_path(conn, :show, group)
       assert Repo.get(UserGroup, user_group.id)
     end

--- a/test/models/user_group_test.exs
+++ b/test/models/user_group_test.exs
@@ -1,0 +1,61 @@
+defmodule Pairmotron.UserGroupTest do
+  use Pairmotron.ModelCase
+
+  alias Pairmotron.UserGroup
+
+  describe "changeset/2" do
+    test "with valid attributes is valid" do
+      changeset = UserGroup.changeset(%UserGroup{}, %{user_id: 1, group_id: 1})
+      assert changeset.valid?
+    end
+
+    test "invalid without user_id" do
+      changeset = UserGroup.changeset(%UserGroup{}, %{group_id: 1})
+      refute changeset.valid?
+    end
+
+    test "invalid without group_id" do
+      changeset = UserGroup.changeset(%UserGroup{}, %{user_id: 1})
+      refute changeset.valid?
+    end
+  end
+
+  describe "user_group_for_user_and_group/2" do
+    test "returns user_group with :user and :group preloaded when it exists" do
+      user = insert(:user)
+      group = insert(:group, %{users: [user]})
+      user_group = UserGroup.user_group_for_user_and_group(user.id, group.id) |> Repo.one
+      refute is_nil(user_group)
+      assert Ecto.assoc_loaded?(user_group.user)
+      assert Ecto.assoc_loaded?(user_group.group)
+    end
+
+    test "returns user_group with :user and :group preloaded when it exists and ids are binaries" do
+      user = insert(:user)
+      group = insert(:group, %{users: [user]})
+      user_group = UserGroup.user_group_for_user_and_group(Integer.to_string(user.id), Integer.to_string(group.id)) |> Repo.one
+      refute is_nil(user_group)
+      assert Ecto.assoc_loaded?(user_group.user)
+      assert Ecto.assoc_loaded?(user_group.group)
+    end
+
+    test "returns nil if user is not in group" do
+      user = insert(:user)
+      group = insert(:group)
+      user_group = UserGroup.user_group_for_user_and_group(user.id, group.id) |> Repo.one
+      assert is_nil(user_group)
+    end
+
+    test "returns nil if user does not exist" do
+      group = insert(:group)
+      user_group = UserGroup.user_group_for_user_and_group(123, group.id) |> Repo.one
+      assert is_nil(user_group)
+    end
+
+    test "returns nil if group does not exist" do
+      user = insert(:user)
+      user_group = UserGroup.user_group_for_user_and_group(user.id, 123) |> Repo.one
+      assert is_nil(user_group)
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -70,4 +70,11 @@ defmodule Pairmotron.Factory do
       pair: build(:pair)
     }
   end
+
+  def user_group_factory do
+    %Pairmotron.UserGroup{
+      user: build(:user),
+      group: build(:group)
+    }
+  end
 end

--- a/web/controllers/user_group_controller.ex
+++ b/web/controllers/user_group_controller.ex
@@ -17,8 +17,9 @@ defmodule Pairmotron.UserGroupController do
   group.
   """
   @spec delete(Plug.Conn.t, map()) :: Plug.Conn.t
-  def delete(conn, %{"id" => id}) do
-    user_group = UserGroup |> Repo.get!(id) |> Repo.preload(:group)
+  def delete(conn, %{"group_id" => group_id, "user_id" => user_id}) do
+    #user_group = UserGroup |> Repo.get!(id) |> Repo.preload(:group)
+    user_group = UserGroup.user_group_for_user_and_group(user_id, group_id) |> Repo.one
 
     current_user = conn.assigns.current_user
     cond do

--- a/web/controllers/user_group_controller.ex
+++ b/web/controllers/user_group_controller.ex
@@ -1,0 +1,42 @@
+defmodule Pairmotron.UserGroupController do
+  @moduledoc """
+  Responsible for actions involving interacting with group membership directly.
+
+  The :delete action deletes a UserGroup record which has the effect of
+  removing a user from a group.
+  """
+  use Pairmotron.Web, :controller
+
+  alias Pairmotron.UserGroup
+  import Pairmotron.ControllerHelpers
+
+  @doc """
+  Deletes the specified UserGroup record if the logged in user is associated
+  with the UserGroup or is the owner of the UserGroup's group association (or
+  has sufficient privileges for that group). This removes that user from that
+  group.
+  """
+  @spec delete(Plug.Conn.t, map()) :: Plug.Conn.t
+  def delete(conn, %{"id" => id}) do
+    user_group = UserGroup |> Repo.get!(id) |> Repo.preload(:group)
+
+    current_user = conn.assigns.current_user
+    cond do
+      current_user.id == user_group.user_id ->
+        delete_user_group_and_redirect(conn, user_group, profile_path(conn, :show))
+      current_user.id == user_group.group.owner_id ->
+        delete_user_group_and_redirect(conn, user_group, group_path(conn, :show, user_group.group))
+      true ->
+        redirect_not_authorized(conn, group_path(conn, :show, user_group.group))
+    end
+  end
+
+  @spec delete_user_group_and_redirect(Plug.Conn.t, Types.user_group, binary()) :: Plug.Conn.t
+  defp delete_user_group_and_redirect(conn, user_group, redirect_path) do
+    Repo.delete!(user_group)
+
+    conn
+    |> put_flash(:info, "User removed from group successfully.")
+    |> redirect(to: redirect_path)
+  end
+end

--- a/web/controllers/user_group_controller.ex
+++ b/web/controllers/user_group_controller.ex
@@ -19,7 +19,7 @@ defmodule Pairmotron.UserGroupController do
   @spec delete(Plug.Conn.t, map()) :: Plug.Conn.t
   def delete(conn, %{"group_id" => group_id, "user_id" => user_id}) do
     #user_group = UserGroup |> Repo.get!(id) |> Repo.preload(:group)
-    user_group = UserGroup.user_group_for_user_and_group(user_id, group_id) |> Repo.one
+    user_group = user_id |> UserGroup.user_group_for_user_and_group(group_id) |> Repo.one
 
     current_user = conn.assigns.current_user
     cond do

--- a/web/controllers/user_group_controller.ex
+++ b/web/controllers/user_group_controller.ex
@@ -23,6 +23,10 @@ defmodule Pairmotron.UserGroupController do
 
     current_user = conn.assigns.current_user
     cond do
+      is_nil(user_group) ->
+        conn
+        |> put_flash(:error, "User's Group Membership record does not exist")
+        |> redirect(to: pair_path(conn, :index))
       current_user.id == user_group.user_id ->
         delete_user_group_and_redirect(conn, user_group, profile_path(conn, :show))
       current_user.id == user_group.group.owner_id ->

--- a/web/models/user_group.ex
+++ b/web/models/user_group.ex
@@ -26,6 +26,11 @@ defmodule Pairmotron.UserGroup do
     |> unique_constraint(:user_id_group_id, [:user_id, :group_id])
   end
 
+  @doc """
+  Returns a query to retrieve the UserGroup associated with the user and group
+  along with the :user and :group associations preloaded.
+  """
+  @spec user_group_for_user_and_group(integer() | binary(), integer() | binary()) :: Ecto.Query.t
   def user_group_for_user_and_group(user_id, group_id) do
     from user_group in Pairmotron.UserGroup,
     join: user in assoc(user_group, :user),

--- a/web/models/user_group.ex
+++ b/web/models/user_group.ex
@@ -25,4 +25,13 @@ defmodule Pairmotron.UserGroup do
     |> validate_required(@required_fields)
     |> unique_constraint(:user_id_group_id, [:user_id, :group_id])
   end
+
+  def user_group_for_user_and_group(user_id, group_id) do
+    from user_group in Pairmotron.UserGroup,
+    join: user in assoc(user_group, :user),
+    join: group in assoc(user_group, :group),
+    where: user.id == ^user_id,
+    where: group.id == ^group_id,
+    preload: [user: user, group: group]
+  end
 end

--- a/web/router.ex
+++ b/web/router.ex
@@ -59,7 +59,7 @@ defmodule Pairmotron.Router do
     resources "/groups/:group_id/invitations", GroupInvitationController, only: [:index, :new, :create, :update, :delete]
     resources "/invitations", UsersGroupMembershipRequestController, only: [:index, :create, :update, :delete]
     resources "/groups", GroupController
-    delete "/group_membership/:id", UserGroupController, :delete
+    delete "/groups/:group_id/users/:user_id", UserGroupController, :delete
 
     get "/pair_retros/new/:pair_id", PairRetroController, :new
     resources "/pair_retros", PairRetroController, except: [:new]

--- a/web/router.ex
+++ b/web/router.ex
@@ -59,6 +59,7 @@ defmodule Pairmotron.Router do
     resources "/groups/:group_id/invitations", GroupInvitationController, only: [:index, :new, :create, :update, :delete]
     resources "/invitations", UsersGroupMembershipRequestController, only: [:index, :create, :update, :delete]
     resources "/groups", GroupController
+    delete "/group_membership/:id", UserGroupController, :delete
 
     get "/pair_retros/new/:pair_id", PairRetroController, :new
     resources "/pair_retros", PairRetroController, except: [:new]

--- a/web/templates/group/group_actions.html.eex
+++ b/web/templates/group/group_actions.html.eex
@@ -21,6 +21,11 @@
     <a href=<%= group_path(@conn, :edit, @group) %>>
       <button class="btn btn-primary btn-sm">Edit</button>
     </a>
+  <%= end %>
+  <%= if current_user_in_group?(@conn, @group) do %>
+    <%= link "Leave Group", to: user_group_path(@conn, :delete, @group, @conn.assigns.current_user), method: :delete, data: [confirm: "Are you sure you want to leave this group?"], class: "btn btn-danger btn-sm" %>
+  <%= end %>
+  <%= if current_user_can_edit_group?(@conn, @group) do %>
     <% delete_warning = "Are you sure? Deleting a group will irreversibly remove all users, pairs, and projects from that group." %>
     <%= link "Delete", to: group_path(@conn, :delete, @group), method: :delete, data: [confirm: delete_warning], class: "btn btn-danger btn-sm" %>
   <%= end %>


### PR DESCRIPTION
Adds the ability for users to leave a group and also the UI to do so. Technically adds the ability for group owners to be able to delete users from a group but there is currently no UI with which to do so. That will be handled by #74 

Adds the user_group ex_machina factory.

- [x] Adds the UserGroupController and the delete action
- [x] Adds the UI to allow users to leave a group that they are in.
- [x] Add tests around non-existent user or group for deletion
- [x] Add tests around new query in UserGroup.

<img width="787" alt="newgroups" src="https://cloud.githubusercontent.com/assets/6462927/24073884/213bc654-0bd5-11e7-8512-42f9993a5514.png">
