### PR TITLE
Fix Ecto.Changeset.cast/4 warnings

### DIFF
--- a/web/models/group.ex
+++ b/web/models/group.ex
@@ -22,8 +22,8 @@ defmodule Pairmotron.Group do
     timestamps()
   end
 
-  @required_fields ~w(name owner_id)
-  @optional_fields ~w(description)
+  @all_fields ~w(name owner_id description)
+  @required_fields [:name, :owner_id]
 
   @doc """
   Builds a changeset based on the `struct` and `params`.
@@ -31,7 +31,8 @@ defmodule Pairmotron.Group do
   @spec changeset(map() | %Ecto.Changeset{}, map()) :: %Ecto.Changeset{}
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, @required_fields, @optional_fields)
+    |> cast(params, @all_fields)
+    |> validate_required(@required_fields)
     |> Sanitizer.sanitize([:name, :description])
     |> foreign_key_constraint(:owner_id)
   end

--- a/web/models/group_membership_request.ex
+++ b/web/models/group_membership_request.ex
@@ -28,8 +28,8 @@ defmodule Pairmotron.GroupMembershipRequest do
     timestamps()
   end
 
-  @required_params ~w(initiated_by_user user_id group_id)
-  @optional_params ~w()
+  @all_params ~w(initiated_by_user user_id group_id)
+  @required_params [:initiated_by_user, :user_id, :group_id]
 
   @doc """
   Builds a changeset based on the `struct` and `params`.
@@ -37,7 +37,8 @@ defmodule Pairmotron.GroupMembershipRequest do
   @spec changeset(map() | %Ecto.Changeset{}, map()) :: %Ecto.Changeset{}
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, @required_params, @optional_params)
+    |> cast(params, @all_params)
+    |> validate_required(@required_params)
     |> foreign_key_constraint(:user_id)
     |> foreign_key_constraint(:group_id)
     |> unique_constraint(:user_id_group_id, [message: "User is already invited to this group"])

--- a/web/models/pair.ex
+++ b/web/models/pair.ex
@@ -18,8 +18,8 @@ defmodule Pairmotron.Pair do
     timestamps()
   end
 
-  @required_fields ~w(year week group_id)
-  @optional_fields ~w()
+  @all_fields ~w(year week group_id)
+  @required_fields [:year, :week, :group_id]
 
   @doc """
   Builds a changeset based on the `struct` and `params`.
@@ -27,7 +27,8 @@ defmodule Pairmotron.Pair do
   @spec changeset(map() | %Ecto.Changeset{}, map()) :: %Ecto.Changeset{}
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, @required_fields, @optional_fields)
+    |> cast(params, @all_fields)
+    |> validate_required(@required_fields)
   end
 
   @doc """

--- a/web/models/pair_retro.ex
+++ b/web/models/pair_retro.ex
@@ -54,6 +54,7 @@ defmodule Pairmotron.PairRetro do
     |> validate_project_is_for_group(:project_id, pair, project)
   end
 
+  @all_update_fields ~w(pair_date subject reflection project_id)
   @required_update_fields [:pair_date]
 
   @doc """
@@ -71,7 +72,7 @@ defmodule Pairmotron.PairRetro do
   @spec update_changeset(map() | %Ecto.Changeset{}, map(), Types.pair, Types.project) :: %Ecto.Changeset{}
   def update_changeset(struct, params \\ %{}, pair, project) do
     struct
-    |> cast(params, @all_fields)
+    |> cast(params, @all_update_fields)
     |> validate_required(@required_update_fields)
     |> Sanitizer.sanitize([:subject, :reflection])
     |> foreign_key_constraint(:project_id)

--- a/web/models/pair_retro.ex
+++ b/web/models/pair_retro.ex
@@ -25,8 +25,8 @@ defmodule Pairmotron.PairRetro do
     timestamps()
   end
 
-  @required_fields ~w(pair_date user_id pair_id)
-  @optional_fields ~w(subject reflection project_id)
+  @all_fields ~w(pair_date user_id pair_id subject reflection project_id)
+  @required_fields [:pair_date, :user_id, :pair_id]
 
   @doc """
   Builds a changeset based on the `struct` and `params`.
@@ -43,7 +43,8 @@ defmodule Pairmotron.PairRetro do
   @spec changeset(map() | %Ecto.Changeset{}, map(), Types.pair, Types.project) :: %Ecto.Changeset{}
   def changeset(struct, params \\ %{}, pair, project) do
     struct
-    |> cast(params, @required_fields, @optional_fields)
+    |> cast(params, @all_fields)
+    |> validate_required(@required_fields)
     |> Sanitizer.sanitize([:subject, :reflection])
     |> foreign_key_constraint(:user_id)
     |> foreign_key_constraint(:pair_id)
@@ -53,7 +54,7 @@ defmodule Pairmotron.PairRetro do
     |> validate_project_is_for_group(:project_id, pair, project)
   end
 
-  @required_update_fields ~w(pair_date)
+  @required_update_fields [:pair_date]
 
   @doc """
   Builds a changeset based on the `struct` and `params`.
@@ -70,7 +71,8 @@ defmodule Pairmotron.PairRetro do
   @spec update_changeset(map() | %Ecto.Changeset{}, map(), Types.pair, Types.project) :: %Ecto.Changeset{}
   def update_changeset(struct, params \\ %{}, pair, project) do
     struct
-    |> cast(params, @required_update_fields, @optional_fields)
+    |> cast(params, @all_fields)
+    |> validate_required(@required_update_fields)
     |> Sanitizer.sanitize([:subject, :reflection])
     |> foreign_key_constraint(:project_id)
     |> validate_date_is_not_before_pair(:pair_date, pair)

--- a/web/models/project.ex
+++ b/web/models/project.ex
@@ -20,8 +20,8 @@ defmodule Pairmotron.Project do
     timestamps()
   end
 
-  @required_params ~w(name)
-  @optional_params ~w(description url group_id created_by_id)
+  @all_params ~w(name description url group_id created_by_id)
+  @required_params [:name]
 
   @doc """
   Builds a changeset based on the `struct` and `params`.
@@ -29,27 +29,33 @@ defmodule Pairmotron.Project do
   @spec changeset(map() | %Ecto.Changeset{}, map()) :: %Ecto.Changeset{}
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, @required_params, @optional_params)
+    |> cast(params, @all_params)
+    |> validate_required(@required_params)
     |> Sanitizer.sanitize([:name, :description, :url])
     |> validate_url(:url)
   end
 
-  @required_create_params ~w(name group_id created_by_id)
-  @optional_change_params ~w(description url)
+  @all_create_params ~w(name group_id created_by_id description url)
+  @required_create_params [:name, :group_id, :created_by_id]
 
   @spec changeset_for_create(map() | %Ecto.Changeset{}, map(), [Types.group]) :: %Ecto.Changeset{}
   def changeset_for_create(struct, params \\ %{}, users_groups) do
     struct
-    |> cast(params, @required_create_params, @optional_change_params)
+    |> cast(params, @all_create_params)
+    |> validate_required(@required_create_params)
     |> Sanitizer.sanitize([:name, :description, :url])
     |> validate_url(:url)
     |> validate_user_is_in_group(:group_id, users_groups)
   end
 
+  @all_change_params ~w(name description url)
+  @required_change_params [:name]
+
   @spec changeset_for_update(map() | %Ecto.Changeset{}, map()) :: %Ecto.Changeset{}
   def changeset_for_update(struct, params \\ %{}) do
     struct
-    |> cast(params, @required_params, @optional_change_params)
+    |> cast(params, @all_change_params)
+    |> validate_required(@required_change_params)
     |> Sanitizer.sanitize([:name, :description, :url])
     |> validate_url(:url)
   end

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -32,8 +32,8 @@ defmodule Pairmotron.User do
 
   @minimum_password_length 8
 
-  @required_params ~w(name email)
-  @optional_params ~w(password password_confirmation active is_admin)
+  @all_params ~w(name email password password_confirmation active is_admin)
+  @required_params [:name, :email]
 
   @doc """
   Builds a changeset based on the `struct` and `params`.
@@ -45,12 +45,13 @@ defmodule Pairmotron.User do
   @spec changeset(map() | %Ecto.Changeset{}, map()) :: %Ecto.Changeset{}
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, @required_params, @optional_params)
+    |> cast(params, @all_params)
+    |> validate_required(@required_params)
     |> common_changeset
   end
 
-  @required_registration_params ~w(name email password password_confirmation)
-  @optional_registration_params ~w(active)
+  @all_registration_params ~w(name email password password_confirmation active)
+  @required_registration_params [:name, :email, :password, :password_confirmation]
 
   @doc """
   Builds a changeset based on the `struct` and `params`.
@@ -62,12 +63,13 @@ defmodule Pairmotron.User do
   @spec registration_changeset(map() | %Ecto.Changeset{}, map()) :: %Ecto.Changeset{}
   def registration_changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, @required_registration_params, @optional_registration_params)
+    |> cast(params, @all_registration_params)
+    |> validate_required(@required_registration_params)
     |> common_changeset
   end
 
-  @required_profile_params ~w(name email)
-  @optional_profile_params ~w(active password password_confirmation)
+  @all_profile_params ~w(name email active password password_confirmation)
+  @required_profile_params [:name, :email]
 
   @doc """
   Builds a changeset based on the `struct` and `params`.
@@ -80,7 +82,8 @@ defmodule Pairmotron.User do
   @spec profile_changeset(map() | %Ecto.Changeset{}, map()) :: %Ecto.Changeset{}
   def profile_changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, @required_profile_params, @optional_profile_params)
+    |> cast(params, @all_profile_params)
+    |> validate_required(@required_profile_params)
     |> common_changeset
   end
 

--- a/web/models/user_group.ex
+++ b/web/models/user_group.ex
@@ -9,8 +9,8 @@ defmodule Pairmotron.UserGroup do
     belongs_to :user, Pairmotron.User
     belongs_to :group, Pairmotron.Group
 
-    @required_fields ~w(group_id user_id)
-    @optional_fields ~w()
+    @all_fields ~w(group_id user_id)
+    @required_fields [:group_id, :user_id]
 
     timestamps()
   end
@@ -21,7 +21,8 @@ defmodule Pairmotron.UserGroup do
   @spec changeset(map() | %Ecto.Changeset{}, map()) :: %Ecto.Changeset{}
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, @required_fields, @optional_fields)
+    |> cast(params, @all_fields)
+    |> validate_required(@required_fields)
     |> unique_constraint(:user_id_group_id, [:user_id, :group_id])
   end
 end

--- a/web/models/user_pair.ex
+++ b/web/models/user_pair.ex
@@ -9,8 +9,8 @@ defmodule Pairmotron.UserPair do
     belongs_to :user, Pairmotron.User
     belongs_to :pair, Pairmotron.Pair
 
-    @required_fields ~w(pair_id user_id)
-    @optional_fields ~w()
+    @all_fields ~w(pair_id user_id)
+    @required_fields [:pair_id, :user_id]
 
     timestamps()
   end
@@ -21,6 +21,7 @@ defmodule Pairmotron.UserPair do
   @spec changeset(map() | %Ecto.Changeset{}, map()) :: %Ecto.Changeset{}
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, @required_fields, @optional_fields)
+    |> cast(params, @all_fields)
+    |> validate_required(@required_fields)
   end
 end


### PR DESCRIPTION
Converted all changesets to using Ecto.Changeset.cast/3 and Ecto.Changeset.validate_required/2 instead of Ecto.Changeset.cast/4 which was deprecated in Ecto 2.1.