### PR TITLE
Add a list of users to the Group show action

### DIFF
--- a/test/controllers/group_controller_test.exs
+++ b/test/controllers/group_controller_test.exs
@@ -240,10 +240,10 @@ defmodule Pairmotron.GroupControllerTest do
       assert html_response(conn, 200) =~ users_group_membership_request_path(conn, :update, group_membership_request)
     end
 
-    test "renders page not found when id is nonexistent", %{conn: conn} do
-      assert_error_sent 404, fn ->
-        get conn, group_path(conn, :show, -1)
-      end
+    test "redirects to group index with error if id is nonexistent", %{conn: conn} do
+      conn = get conn, group_path(conn, :show, -1)
+      assert redirected_to(conn) == group_path(conn, :index)
+      assert %{private: %{phoenix_flash: %{"error" => "Group does not exist"}}} = conn
     end
   end
 
@@ -504,10 +504,10 @@ defmodule Pairmotron.GroupControllerTest do
       assert html_response(conn, 200) =~ users_group_membership_request_path(conn, :update, group_membership_request)
     end
 
-    test "renders page not found when id is nonexistent", %{conn: conn} do
-      assert_error_sent 404, fn ->
-        get conn, group_path(conn, :show, -1)
-      end
+    test "redirects to group index with error if id is nonexistent", %{conn: conn} do
+      conn = get conn, group_path(conn, :show, -1)
+      assert redirected_to(conn) == group_path(conn, :index)
+      assert %{private: %{phoenix_flash: %{"error" => "Group does not exist"}}} = conn
     end
   end
 

--- a/web/models/group.ex
+++ b/web/models/group.ex
@@ -48,6 +48,19 @@ defmodule Pairmotron.Group do
     |> put_assoc(:users, users)
   end
 
+  @doc """
+  Returns a query that returns the group with the given group id, and the
+  :owner and :users associations preloaded. Executes in a single database call.
+  """
+  @spec group_with_owner_and_users(integer() | binary()) :: Ecto.Query.t
+  def group_with_owner_and_users(group_id) do
+    from group in Pairmotron.Group,
+    left_join: owner in assoc(group, :owner),
+    left_join: users in assoc(group, :users),
+    where: group.id == ^group_id,
+    preload: [owner: owner, users: users]
+  end
+
   @spec groups_for_user(Types.user) :: %Ecto.Query{}
   def groups_for_user(user) do
     from group in Pairmotron.Group,

--- a/web/templates/group/show.html.eex
+++ b/web/templates/group/show.html.eex
@@ -13,7 +13,7 @@
 </h2>
 <p><%= @group.description %></p>
 <%= render "group_actions.html", conn: @conn, group: @group %>
-<h2>Users</h2>
+<h2>Members</h2>
 <table class="table">
   <thead>
     <tr>

--- a/web/templates/group/show.html.eex
+++ b/web/templates/group/show.html.eex
@@ -13,3 +13,21 @@
 </h2>
 <p><%= @group.description %></p>
 <%= render "group_actions.html", conn: @conn, group: @group %>
+<h2>Users</h2>
+<table class="table">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th />
+    </tr>
+  </thead>
+  <tbody>
+    <%= for user <- @group.users do %>
+      <tr>
+        <td>
+          <%= user.name %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>


### PR DESCRIPTION
This PR is pretty simple, but lays the groundwork for a lot of other work such as group roles and ejecting users from groups. It's also useful information to know. The only piece of information listed for each user is currently their name.

An alternative implementation would be to add this information to the UserGroup controller under the :index action where it thematically makes sense, and is probably a bit more RESTful. Let me know what you think of this. The reason that I didn't go with this route in the first place, was that I didn't want users to have to travel too far to get to this information (a weak argument).

Closes #114 