### PR TITLE
Add create retro and edit retro links to /pairs

### DIFF
--- a/lib/pairmotron/pair_maker.ex
+++ b/lib/pairmotron/pair_maker.ex
@@ -9,14 +9,15 @@ defmodule Pairmotron.PairMaker do
   @doc """
   Retrieves pairs for a given period and group. Generates pairs if none are found.
   """
-  @spec fetch_or_gen(number, number, number) :: {:ok, List.t} | {:error, String.t}
+  @spec fetch_or_gen(number, number, number) :: {:ok, [Types.pair], nil} | {:error, [Types.pair], String.t}
   def fetch_or_gen(year, week, group_id) do
     case fetch_pairs(year, week, group_id) do
       []    -> generate_and_fetch_if_current_week(year, week, group_id)
-      pairs -> {:ok, pairs}
+      pairs -> {:ok, pairs, nil}
     end
   end
 
+  @spec generate_and_fetch_if_current_week(integer(), 1..53, integer()) :: {:error | :ok, [Types.pair], String.t | nil}
   defp generate_and_fetch_if_current_week(year, week, group_id) do
     case Pairmotron.Calendar.same_week?(year, week, Timex.today) do
       true ->
@@ -30,9 +31,11 @@ defmodule Pairmotron.PairMaker do
     end
   end
 
+  @spec prepare_result({:error, String.t} | {:ok, any()}, [Types.pair]) :: {:error | :ok, [Types.pair], String.t | nil}
   defp prepare_result({:error, message}, pairs), do: {:error, pairs, message}
-  defp prepare_result({:ok, _}, pairs), do: {:ok, pairs}
+  defp prepare_result({:ok, _}, pairs), do: {:ok, pairs, nil}
 
+  @spec fetch_pairs(integer(), 1..53, integer()) :: [Types.pair]
   defp fetch_pairs(year, week, group_id) do
     Pair
       |> where(year: ^year, week: ^week, group_id: ^group_id)

--- a/test/controllers/pair_controller_test.exs
+++ b/test/controllers/pair_controller_test.exs
@@ -39,32 +39,32 @@ defmodule Pairmotron.PairControllerTest do
       %{conn: conn, logged_in_user: user, group: group} do
       pair = Pairmotron.TestHelper.create_pair([user], group)
       conn = get(conn, "/pairs")
-      refute html_response(conn, 200) =~ pair_retro_path(conn, :new, pair.id)
+      assert html_response(conn, 200) =~ pair_retro_path(conn, :new, pair.id)
     end
 
-    test "does not display link to retro :create when the other user in pair has retro but current_user doesn't",
+    test "displays link to retro :create when the other user in pair has retro but current_user doesn't",
       %{conn: conn, logged_in_user: user, group: group} do
       other_user = insert(:user)
-      pair = Pairmotron.TestHelper.create_pair([user, other_user], group)
-      create_retro(other_user, pair)
+      pair = insert(:pair, group: group, users: [user, other_user])
+      insert(:retro, %{pair: pair, user: other_user})
       conn = get(conn, "/pairs")
-      refute html_response(conn, 200) =~ pair_retro_path(conn, :new, pair.id)
+      assert html_response(conn, 200) =~ pair_retro_path(conn, :new, pair.id)
     end
 
-    test "does not display link to retro :show for pair and current user with retrospective",
+    test "displays link to retro :show for pair and current user with retrospective",
       %{conn: conn, logged_in_user: user, group: group} do
       {_pair, retro} = create_pair_and_retro(user, group)
       conn = get(conn, "/pairs")
-      refute html_response(conn, 200) =~ pair_retro_path(conn, :show, retro.id)
+      assert html_response(conn, 200) =~ pair_retro_path(conn, :show, retro.id)
     end
 
-    test "does not display link to retro :show for pair and current user with retrospective for :show",
+    test "displays link to retro :show for pair and current user with retrospective for :show",
       %{conn: conn, logged_in_user: user, group: group} do
       {year, week} = Timex.iso_week(Timex.today)
       pair = Pairmotron.TestHelper.create_pair([user], group, year, week)
       retro = create_retro(user, pair) # create_retro function defines pair_date as Timex.today
       conn = get conn, pair_path(conn, :show, year, week)
-      refute html_response(conn, 200) =~ pair_retro_path(conn, :show, retro.id)
+      assert html_response(conn, 200) =~ pair_retro_path(conn, :show, retro.id)
     end
 
     test "displays each of the user's groups' pairs (only the pairs including the user)", %{conn: conn, logged_in_user: user, group: group} do

--- a/test/controllers/pair_controller_test.exs
+++ b/test/controllers/pair_controller_test.exs
@@ -2,13 +2,11 @@ defmodule Pairmotron.PairControllerTest do
   use Pairmotron.ConnCase
 
   import Pairmotron.TestHelper,
-    only: [log_in: 2, create_retro: 2, create_pair_and_retro: 2]
+    only: [log_in: 2]
 
   describe "while authenticated and not belonging to any groups" do
     setup do
-      user = insert(:user)
-      conn = build_conn() |> log_in(user)
-      {:ok, [conn: conn, logged_in_user: user]}
+      login_user()
     end
 
     test "displays helpful message when there are no groups", %{conn: conn} do
@@ -53,7 +51,8 @@ defmodule Pairmotron.PairControllerTest do
 
     test "displays link to retro :show for pair and current user with retrospective",
       %{conn: conn, logged_in_user: user, group: group} do
-      {_pair, retro} = create_pair_and_retro(user, group)
+      pair = insert(:pair, %{group: group, users: [user]})
+      retro = insert(:retro, %{user: user, pair: pair})
       conn = get(conn, "/pairs")
       assert html_response(conn, 200) =~ pair_retro_path(conn, :show, retro.id)
     end
@@ -61,8 +60,8 @@ defmodule Pairmotron.PairControllerTest do
     test "displays link to retro :show for pair and current user with retrospective for :show",
       %{conn: conn, logged_in_user: user, group: group} do
       {year, week} = Timex.iso_week(Timex.today)
-      pair = Pairmotron.TestHelper.create_pair([user], group, year, week)
-      retro = create_retro(user, pair) # create_retro function defines pair_date as Timex.today
+      pair = insert(:pair, %{group: group, users: [user], year: year, week: week}) 
+      retro = insert(:retro, %{user: user, pair: pair})
       conn = get conn, pair_path(conn, :show, year, week)
       assert html_response(conn, 200) =~ pair_retro_path(conn, :show, retro.id)
     end

--- a/test/lib/pair_maker_test.exs
+++ b/test/lib/pair_maker_test.exs
@@ -124,7 +124,7 @@ defmodule Pairmotron.PairMakerTest do
       {year, week} = Timex.iso_week(Timex.today)
       assert [] = Repo.all(Pair)
       PairMaker.generate_pairs(year, week, group.id)
-      {:ok, [%Pair{users: [fetched]}]} = PairMaker.fetch_or_gen(year, week, group.id)
+      {:ok, [%Pair{users: [fetched]}], nil} = PairMaker.fetch_or_gen(year, week, group.id)
       assert user.id == fetched.id
       assert [%Pair{}] = Repo.all(Pair)
       [userpair] = Repo.all(UserPair)
@@ -134,7 +134,7 @@ defmodule Pairmotron.PairMakerTest do
     test "generates pairs when current week", %{group: group, user: user} do
       {year, week} = Timex.iso_week(Timex.today)
       assert [] = Repo.all(Pair)
-      {:ok, [%Pair{users: [fetched]}]} = PairMaker.fetch_or_gen(year, week, group.id)
+      {:ok, [%Pair{users: [fetched]}], nil} = PairMaker.fetch_or_gen(year, week, group.id)
       assert user.id == fetched.id
       assert [%Pair{}] = Repo.all(Pair)
       [userpair] = Repo.all(UserPair)

--- a/test/models/pair_retro_test.exs
+++ b/test/models/pair_retro_test.exs
@@ -165,6 +165,47 @@ defmodule Pairmotron.PairRetroTest do
     end
   end
 
+  describe ".retro_for_user_and_pair" do
+    test "returns the retro for the user and pair" do
+      user = insert(:user)
+      pair = insert(:pair, %{users: [user]})
+      insert(:retro, %{user: user, pair: pair})
+
+      assert Repo.one(PairRetro.retro_for_user_and_pair(user, pair))
+    end
+
+    test "returns the retro for the user and pair out of two pairs and retros" do
+      user = insert(:user)
+      pair = insert(:pair, %{users: [user]})
+      retro = insert(:retro, %{user: user, pair: pair})
+      other_pair = insert(:pair, %{users: [user]})
+      _other_retro = insert(:retro, %{user: user, pair: other_pair})
+
+      returned_retros = Repo.all(PairRetro.retro_for_user_and_pair(user, pair))
+      assert [returned_retro] = returned_retros
+      assert returned_retro.id == retro.id
+    end
+
+    test "returns the retro for the pair and user out of two users and retros" do
+      user = insert(:user)
+      other_user = insert(:user)
+      pair = insert(:pair, %{users: [user, other_user]})
+      retro = insert(:retro, %{user: user, pair: pair})
+      _other_retro = insert(:retro, %{user: other_user, pair: pair})
+
+      returned_retros = Repo.all(PairRetro.retro_for_user_and_pair(user, pair))
+      assert [returned_retro] = returned_retros
+      assert returned_retro.id == retro.id
+    end
+
+    test "returns no retro if there are no retros" do
+      user = insert(:user)
+      pair = insert(:pair, %{users: [user]})
+
+      refute Repo.one(PairRetro.retro_for_user_and_pair(user, pair))
+    end
+  end
+
   describe ".users_retros" do
     test "returns nil when there are no retros" do
       user = insert(:user)

--- a/web/controllers/controller_helpers.ex
+++ b/web/controllers/controller_helpers.ex
@@ -7,7 +7,6 @@ defmodule Pairmotron.ControllerHelpers do
 
   import Plug.Conn
   import Phoenix.Controller
-  alias Pairmotron.{Repo, PairRetro}
 
   @doc """
   Renders a 404 message.
@@ -60,15 +59,5 @@ defmodule Pairmotron.ControllerHelpers do
   @spec is_admin?(Types.user) :: boolean()
   def is_admin?(user) do
     user.is_admin
-  end
-
-  @doc """
-  Assigns a retro to the current user for a given year and week
-  """
-  @spec assign_current_user_pair_retro_for_week(%Plug.Conn{}, integer(), 1..53) :: %Plug.Conn{}
-  def assign_current_user_pair_retro_for_week(conn, year, week) do
-    current_user = conn.assigns[:current_user]
-    retro = Repo.one(PairRetro.retro_for_user_and_week(current_user, year, week))
-    Plug.Conn.assign(conn, :current_user_retro_for_week, retro)
   end
 end

--- a/web/controllers/group_pair_controller.ex
+++ b/web/controllers/group_pair_controller.ex
@@ -54,7 +54,7 @@ defmodule Pairmotron.GroupPairController do
     case PairMaker.fetch_or_gen(year, week, group_id) do
       {:error, pairs, message} ->
         {conn |> put_flash(:error, message), pairs}
-      {:ok, pairs} ->
+      {:ok, pairs, _} ->
         {conn, pairs}
     end
   end

--- a/web/controllers/group_pair_controller.ex
+++ b/web/controllers/group_pair_controller.ex
@@ -45,7 +45,7 @@ defmodule Pairmotron.GroupPairController do
   end
 
   defp authorized?(group, user) do
-    group = group |> Pairmotron.Repo.preload(:users)
+    group = group |> Repo.preload(:users)
     group.users
       |> Enum.any?(fn guser -> guser.id == user.id end)
   end
@@ -66,5 +66,12 @@ defmodule Pairmotron.GroupPairController do
       {:ok, _} ->
         conn |> put_flash(:info, "Repairified")
     end
+  end
+
+  @spec assign_current_user_pair_retro_for_week(%Plug.Conn{}, integer(), 1..53) :: %Plug.Conn{}
+  defp assign_current_user_pair_retro_for_week(conn, year, week) do
+    current_user = conn.assigns[:current_user]
+    retro = Repo.one(Pairmotron.PairRetro.retro_for_user_and_week(current_user, year, week))
+    Plug.Conn.assign(conn, :current_user_retro_for_week, retro)
   end
 end

--- a/web/controllers/pair_controller.ex
+++ b/web/controllers/pair_controller.ex
@@ -6,6 +6,8 @@ defmodule Pairmotron.PairController do
 
   alias Pairmotron.PairMaker
 
+  @typep pair_session :: [{Types.group, [{Type.pair, Types.retro | nil}]}]
+
   @spec index(Plug.Conn.t, map()) :: Plug.Conn.t
   def index(conn, _params) do
     {year, week} = Timex.iso_week(Timex.today)
@@ -29,20 +31,20 @@ defmodule Pairmotron.PairController do
     |> render_index(year, week, groups_and_pairs)
   end
 
-  @spec render_index(Plug.Conn.t, integer(), 1..53, [{Types.group, [{Types.pair, Types.retro | nil}]}]) :: Plug.Conn.t
+  @spec render_index(Plug.Conn.t, integer(), 1..53, pair_session) :: Plug.Conn.t
   defp render_index(conn, year, week, groups_and_pairs) do
     render(conn, "index.html", year: year, week: week, groups_and_pairs: groups_and_pairs,
               start_date: Timex.from_iso_triplet({year, week, 1}),
               stop_date: Timex.from_iso_triplet({year, week, 7}))
   end
 
-  @spec fetch_groups_and_pairs(Types.user, integer(), 1..53) :: {[{Types.group, [{Types.pair, Types.retro | nil}]}], [String.t]}
+  @spec fetch_groups_and_pairs(Types.user, integer(), 1..53) :: {pair_session, [String.t]}
   defp fetch_groups_and_pairs(user, year, week) do
     user = user |> Repo.preload(:groups)
     groups_with_pairs_for_user(user, year, week)
   end
 
-  @spec groups_with_pairs_for_user(Types.user, integer(), 1..53) :: {[{Types.group, [{Types.pair, Types.retro | nil}]}], [String.t]}
+  @spec groups_with_pairs_for_user(Types.user, integer(), 1..53) :: {pair_session, [String.t]}
   defp groups_with_pairs_for_user(user, year, week) do
     Enum.reduce(user.groups, {[], []},
       fn(group, accum) ->

--- a/web/controllers/pair_controller.ex
+++ b/web/controllers/pair_controller.ex
@@ -47,19 +47,14 @@ defmodule Pairmotron.PairController do
     Enum.reduce(user.groups, {[], []},
       fn(group, accum) ->
         {groups_with_pairs, messages} = accum
-        case PairMaker.fetch_or_gen(year, week, group.id) do
-          {:ok, pairs} ->
-            pairs_and_retros = pairs
-              |> pairs_containing_user(user)
-              |> add_retros_to_pairs_for_user(user)
-            new_groups_with_pairs = groups_with_pairs ++ [{group, pairs_and_retros}]
-            {new_groups_with_pairs, messages}
-          {:error, pairs, message} ->
-            pairs_and_retros = pairs
-              |> pairs_containing_user(user)
-              |> add_retros_to_pairs_for_user(user)
-            new_groups_with_pairs = groups_with_pairs ++ [{group, pairs_and_retros}]
-            {new_groups_with_pairs, [message | messages]}
+        {_, pairs, message} = PairMaker.fetch_or_gen(year, week, group.id)
+        pairs_and_retros = pairs
+          |> pairs_containing_user(user)
+          |> add_retros_to_pairs_for_user(user)
+        new_groups_with_pairs = groups_with_pairs ++ [{group, pairs_and_retros}]
+        case message do
+          nil -> {new_groups_with_pairs, messages}
+          message -> {new_groups_with_pairs, [message | messages]}
         end
       end)
   end

--- a/web/models/pair_retro.ex
+++ b/web/models/pair_retro.ex
@@ -129,6 +129,13 @@ defmodule Pairmotron.PairRetro do
     where: p.week == ^week
   end
 
+  @spec retro_for_user_and_pair(Types.user, Types.pair) :: Ecto.Query.t
+  def retro_for_user_and_pair(user, pair) do
+    from retro in Pairmotron.PairRetro,
+    where: retro.user_id == ^user.id,
+    where: retro.pair_id == ^pair.id
+  end
+
   @spec users_retros(Types.user) :: %Ecto.Query{}
   def users_retros(user) do
     from retro in Pairmotron.PairRetro,

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -24,7 +24,7 @@ defmodule Pairmotron.User do
     field :password_hash, :string
 
     has_many :pair_retros, Pairmotron.PairRetro
-    many_to_many :groups, Pairmotron.Group, join_through: "users_groups"
+    many_to_many :groups, Pairmotron.Group, join_through: Pairmotron.UserGroup
     has_many :group_membership_requests, Pairmotron.GroupMembershipRequest
 
     timestamps()

--- a/web/templates/pair/index.html.eex
+++ b/web/templates/pair/index.html.eex
@@ -3,14 +3,14 @@
   <div class="col-md-8 col-sm-12 col-xs-12">
     <ul class="list-group">
 
-      <%= for {group, pairs} <- @groups_and_pairs do %>
+      <%= for {group, pairs_with_retros} <- @groups_and_pairs do %>
         <h3><%= link group.name, to: group_pair_path(@conn, :show, group.id, @year, @week) %></h3>
-        <%= for pair <- pairs do %>
+        <%= for {pair, retro} <- pairs_with_retros do %>
           <li class="list-group-item">
             <%= render Pairmotron.SharedView, "pair.html", pair: pair, conn: @conn %>
           </li>
         <% end %>
-        <%= if Enum.empty?(pairs) do %>
+        <%= if Enum.empty?(pairs_with_retros) do %>
           <p>No pairs available</p>
         <% end %>
       <% end %>

--- a/web/templates/pair/index.html.eex
+++ b/web/templates/pair/index.html.eex
@@ -8,6 +8,11 @@
         <%= for {pair, retro} <- pairs_with_retros do %>
           <li class="list-group-item">
             <%= render Pairmotron.SharedView, "pair.html", pair: pair, conn: @conn %>
+            <%= if is_nil(retro) do %>
+              <a href="<%= pair_retro_path(@conn, :new, pair.id) %>">Create Retrospective</a>
+            <%= else %>
+              <a href="<%= pair_retro_path(@conn, :edit, retro.id) %>">Retrospective</a>
+            <%= end %>
           </li>
         <% end %>
         <%= if Enum.empty?(pairs_with_retros) do %>


### PR DESCRIPTION
Added back the create retro and edit retro links to /pairs as they were removed because of a bug when group-based pairing was added.

Previously, the query that retrieved retros simply looked for a retro (and unfortunately multiple) that was associated with the user and the year and week (through a pair). This worked fine when it was only possible for a user to be in one pair per week, but it broke down once a user could be in many pairs in the same week due to being in multiple groups. The end effect was if you were paired in Group A and Group B, and created a retrospective for Group A, the "create retro" link would change to "edit retro" for both Group A and Group B, and would link to the retro that you created for Group A under both links. This now works properly.

This also fixed a subtle bug due to zipping the user's groups with the user's pairs for a given week when a user wasn't in a pair for all of their groups that week. If that pair that they weren't in was not the last group in the list of groups (order was arbitrary), then the pairs could shift to a different group. Pairs are now connected to groups explicitly, so it is possible for the second group out of three to not have a pair for the current user and have it display properly.

Although not a possible case presently, the /pairs route will now properly display multiple pairs for a group if the user is in multiple pairs.

Closes #126