### PR TITLE
Add group specific admin

### DIFF
--- a/priv/repo/migrations/20170326201602_add-user-group-is-admin.exs
+++ b/priv/repo/migrations/20170326201602_add-user-group-is-admin.exs
@@ -1,0 +1,21 @@
+defmodule :"Elixir.Pairmotron.Repo.Migrations.Add-user-group-is-admin" do
+  use Ecto.Migration
+
+  def up do
+    alter table(:users_groups) do
+      add :is_admin, :boolean
+    end
+
+    execute "UPDATE users_groups SET is_admin = FALSE where is_admin IS NULL"
+
+    alter table (:users_groups) do
+      modify :is_admin, :boolean, null: false, default: false
+    end
+  end
+
+  def down do
+    alter table(:users_groups) do
+      remove :is_admin
+    end
+  end
+end

--- a/priv/repo/migrations/20170326201602_add-user-group-is-admin.exs
+++ b/priv/repo/migrations/20170326201602_add-user-group-is-admin.exs
@@ -1,21 +1,9 @@
 defmodule :"Elixir.Pairmotron.Repo.Migrations.Add-user-group-is-admin" do
   use Ecto.Migration
 
-  def up do
-    alter table(:users_groups) do
-      add :is_admin, :boolean
-    end
-
-    execute "UPDATE users_groups SET is_admin = FALSE where is_admin IS NULL"
-
+  def change do
     alter table (:users_groups) do
-      modify :is_admin, :boolean, null: false, default: false
-    end
-  end
-
-  def down do
-    alter table(:users_groups) do
-      remove :is_admin
+      add :is_admin, :boolean, null: false, default: false
     end
   end
 end

--- a/test/controllers/group_invitation_controller_test.exs
+++ b/test/controllers/group_invitation_controller_test.exs
@@ -196,6 +196,16 @@ defmodule Pairmotron.GroupInvitationControllerTest do
       assert Repo.get_by(UserGroup, %{group_id: group.id, user_id: other_user.id})
     end
 
+    test "upon success, user is not an admin in group", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{owner: user, users: [user]})
+      other_user = insert(:user)
+      group_membership_request = insert(:group_membership_request, %{group: group, user: other_user, initiated_by_user: true})
+      put conn, group_invitation_path(conn, :update, group, group_membership_request), group_membership_request: %{}
+
+      user_group = Repo.get_by(UserGroup, %{group_id: group.id, user_id: other_user.id})
+      assert user_group.is_admin == false
+    end
+
     test "fails if group_membership_request doesn't exist", %{conn: conn, logged_in_user: user} do
       group = insert(:group, %{owner: user, users: [user]})
       other_user = insert(:user)

--- a/test/controllers/user_group_controller_test.exs
+++ b/test/controllers/user_group_controller_test.exs
@@ -22,6 +22,53 @@ defmodule Pairmotron.UserGroupControllerTest do
       conn = get conn, user_group_path(conn, :edit, group, other_user)
       assert html_response(conn, 200) =~ "Edit #{other_user.name}&#39;s membership in #{group.name}"
     end
+
+    test "renders form for editing UserGroup is user is admin in group", %{conn: conn, logged_in_user: user} do
+      other_user = insert(:user)
+      group = insert(:group, %{users: [other_user]})
+      insert(:user_group, %{user: user, group: group, is_admin: true})
+      conn = get conn, user_group_path(conn, :edit, group, other_user)
+      assert html_response(conn, 200) =~ "Edit #{other_user.name}&#39;s membership in #{group.name}"
+    end
+
+    test "rendered form has link to remove user from group", %{conn: conn, logged_in_user: user} do
+      other_user = insert(:user)
+      group = insert(:group, %{owner: user, users: [user, other_user]})
+      conn = get conn, user_group_path(conn, :edit, group, other_user)
+      assert html_response(conn, 200) =~ "Remove from group"
+    end
+
+    test "fails if user is not oner or admin of group", %{conn: conn, logged_in_user: user} do
+      other_user = insert(:user)
+      group = insert(:group, %{users: [user, other_user]})
+      conn = get conn, user_group_path(conn, :edit, group, other_user)
+      assert redirected_to(conn) == group_path(conn, :show, group)
+    end
+
+    test "fails if logged in user is not in group", %{conn: conn} do
+      other_user = insert(:user)
+      group = insert(:group, %{users: [other_user]})
+      conn = get conn, user_group_path(conn, :edit, group, other_user)
+      assert redirected_to(conn) == group_path(conn, :show, group)
+    end
+
+    test "fails if user to be edited is not in group", %{conn: conn, logged_in_user: user} do
+      other_user = insert(:user)
+      group = insert(:group, %{owner: user, users: [user]})
+      conn = get conn, user_group_path(conn, :edit, group, other_user)
+      assert redirected_to(conn) == group_path(conn, :show, group)
+    end
+
+    test "fails if group in route does not exist", %{conn: conn, logged_in_user: user} do
+      conn = get conn, user_group_path(conn, :edit, 123, user)
+      assert redirected_to(conn) == group_path(conn, :show, 123)
+    end
+
+    test "fails is user in route does not exist", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{owner: user, users: [user]})
+      conn = get conn, user_group_path(conn, :edit, group, 123)
+      assert redirected_to(conn) == group_path(conn, :show, group)
+    end
   end
 
   describe "using :delete while authenticated" do

--- a/test/controllers/user_group_controller_test.exs
+++ b/test/controllers/user_group_controller_test.exs
@@ -11,6 +11,19 @@ defmodule Pairmotron.UserGroupControllerTest do
     assert redirected_to(conn) == session_path(conn, :new)
   end
 
+  describe "using :edit while authenticated" do
+    setup do
+      login_user()
+    end
+
+    test "renders form for editing UserGroup if user is owner of group", %{conn: conn, logged_in_user: user} do
+      other_user = insert(:user)
+      group = insert(:group, %{owner: user, users: [user, other_user]})
+      conn = get conn, user_group_path(conn, :edit, group, other_user)
+      assert html_response(conn, 200) =~ "Edit #{other_user.name}&#39;s membership in #{group.name}"
+    end
+  end
+
   describe "using :delete while authenticated" do
     setup do
       login_user()

--- a/test/controllers/users_group_membership_request_controller_test.exs
+++ b/test/controllers/users_group_membership_request_controller_test.exs
@@ -110,7 +110,7 @@ defmodule Pairmotron.UsersGroupMembershipRequestControllerTest do
       login_user()
     end
 
-    test "creates a group and deletes group_invite if group_invite exists and created by group", %{conn: conn, logged_in_user: user} do
+    test "creates a UserGroup and deletes group_invite if group_invite exists and created by group", %{conn: conn, logged_in_user: user} do
       group = insert(:group)
       group_membership_request = insert(:group_membership_request, %{group: group, user: user, initiated_by_user: false})
       conn = put conn, users_group_membership_request_path(conn, :update, group_membership_request), group_membership_request: %{}
@@ -118,6 +118,15 @@ defmodule Pairmotron.UsersGroupMembershipRequestControllerTest do
       assert redirected_to(conn) == users_group_membership_request_path(conn, :index)
       refute Repo.get(GroupMembershipRequest, group_membership_request.id)
       assert Repo.get_by(UserGroup, %{group_id: group.id, user_id: user.id})
+    end
+
+    test "upon success, user is not an admin in the group", %{conn: conn, logged_in_user: user} do
+      group = insert(:group)
+      group_membership_request = insert(:group_membership_request, %{group: group, user: user, initiated_by_user: false})
+      put conn, users_group_membership_request_path(conn, :update, group_membership_request), group_membership_request: %{}
+
+      user_group = Repo.get_by(UserGroup, %{group_id: group.id, user_id: user.id})
+      assert user_group.is_admin == false
     end
 
     test "fails if group_membership_request doesn't exist", %{conn: conn, logged_in_user: user} do

--- a/test/models/user_group_test.exs
+++ b/test/models/user_group_test.exs
@@ -20,6 +20,24 @@ defmodule Pairmotron.UserGroupTest do
     end
   end
 
+  describe "update_changeset/2" do
+    test "can change the is_admin field" do
+      changeset = UserGroup.update_changeset(%UserGroup{}, %{is_admin: true})
+      assert changeset.valid?
+      assert %{changes: %{is_admin: true}} = changeset
+    end
+
+    test "cannot change the user_id field" do
+      changeset = UserGroup.update_changeset(%UserGroup{}, %{user_id: 123})
+      assert %{changes: %{}} = changeset
+    end
+
+    test "cannot change the group_id field" do
+      changeset = UserGroup.update_changeset(%UserGroup{}, %{group_id: 123})
+      assert %{changes: %{}} = changeset
+    end
+  end
+
   describe "user_group_for_user_and_group/2" do
     test "returns user_group with :user and :group preloaded when it exists" do
       user = insert(:user)

--- a/test/models/user_test.exs
+++ b/test/models/user_test.exs
@@ -3,7 +3,7 @@ defmodule Pairmotron.UserTest do
 
   alias Pairmotron.User
 
-  @valid_attrs %{email: "some content", name: "some content"}
+  @valid_attrs %{email: "some content", name: "some content", is_admin: false}
   @invalid_attrs %{}
 
   describe "changeset/2" do

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -74,7 +74,8 @@ defmodule Pairmotron.Factory do
   def user_group_factory do
     %Pairmotron.UserGroup{
       user: build(:user),
-      group: build(:group)
+      group: build(:group),
+      is_admin: false
     }
   end
 end

--- a/web/admin/user_group.ex
+++ b/web/admin/user_group.ex
@@ -3,7 +3,7 @@ defmodule Pairmotron.ExAdmin.UserGroup do
   use ExAdmin.Register
 
   register_resource Pairmotron.UserGroup do
-    filter [:user, :group]
-    action_items only: [:new, :delete, :show]
+    filter [:user, :group, :is_admin]
+    action_items only: [:new, :edit, :delete, :show]
   end
 end

--- a/web/controllers/user_group_controller.ex
+++ b/web/controllers/user_group_controller.ex
@@ -25,6 +25,8 @@ defmodule Pairmotron.UserGroupController do
         render_edit(conn, user_group)
       logged_in_users_user_group.is_admin ->
         render_edit(conn, user_group)
+      user.is_admin ->
+        render_edit(conn, user_group)
       true ->
         redirect_not_authorized(conn, group_path(conn, :show, group_id))
     end

--- a/web/controllers/user_group_controller.ex
+++ b/web/controllers/user_group_controller.ex
@@ -10,6 +10,19 @@ defmodule Pairmotron.UserGroupController do
   alias Pairmotron.UserGroup
   import Pairmotron.ControllerHelpers
 
+  @spec edit(Plug.Conn.t, map()) :: Plug.Conn.t
+  def edit(conn, %{"group_id" => group_id, "user_id" => user_id}) do
+    user_group = user_id |> UserGroup.user_group_for_user_and_group(group_id) |> Repo.one
+
+    changeset = UserGroup.changeset(user_group)
+    render(conn, "edit.html", changeset: changeset, user_group: user_group)
+  end
+
+  @spec update(Plug.Conn.t, map()) :: Plug.Conn.t
+  def update(conn, %{"group_id" => group_id, "user_id" => user_id}) do
+    conn
+  end
+
   @doc """
   Deletes the specified UserGroup record if the logged in user is associated
   with the UserGroup or is the owner of the UserGroup's group association (or

--- a/web/controllers/user_group_controller.ex
+++ b/web/controllers/user_group_controller.ex
@@ -31,13 +31,43 @@ defmodule Pairmotron.UserGroupController do
   end
 
   defp render_edit(conn, user_group) do
-    changeset = UserGroup.changeset(user_group)
+    changeset = UserGroup.update_changeset(user_group)
     render(conn, "edit.html", changeset: changeset, user_group: user_group)
   end
 
   @spec update(Plug.Conn.t, map()) :: Plug.Conn.t
-  def update(conn, %{"group_id" => group_id, "user_id" => user_id}) do
-    conn
+  def update(conn, %{"group_id" => group_id, "user_id" => user_id, "user_group" => user_group_params}) do
+    user_group = user_id |> UserGroup.user_group_for_user_and_group(group_id) |> Repo.one
+    user = conn.assigns.current_user
+    logged_in_users_user_group = user.id |> UserGroup.user_group_for_user_and_group(group_id) |> Repo.one
+
+    cond do
+      is_nil(user_group) ->
+        redirect_not_authorized(conn, group_path(conn, :show, group_id))
+      is_nil(logged_in_users_user_group) ->
+        redirect_not_authorized(conn, group_path(conn, :show, group_id))
+      logged_in_users_user_group.is_admin ->
+        update_user_group(conn, user_group, user_group_params)
+      user_group.group.owner_id == user.id ->
+        update_user_group(conn, user_group, user_group_params)
+      user.is_admin ->
+        update_user_group(conn, user_group, user_group_params)
+      true ->
+        redirect_not_authorized(conn, group_path(conn, :show, group_id))
+    end
+  end
+
+  @spec update_user_group(Plug.Conn.t, Ecto.Changeset.t, Types.user_group) :: Plug.Conn.t
+  defp update_user_group(conn, user_group, params) do
+    changeset = UserGroup.update_changeset(user_group, params)
+    case Repo.update(changeset) do
+      {:ok, _user_group} ->
+        conn
+        |> put_flash(:info, "User's membership updated successfully.")
+        |> redirect(to: group_path(conn, :show, user_group.group_id))
+      {:error, changeset} ->
+        render(conn, "edit.html", changeset: changeset, user_group: user_group)
+    end
   end
 
   @doc """

--- a/web/models/user_group.ex
+++ b/web/models/user_group.ex
@@ -20,12 +20,27 @@ defmodule Pairmotron.UserGroup do
   @doc """
   Builds a changeset based on the `struct` and `params`.
   """
-  @spec changeset(map() | %Ecto.Changeset{}, map()) :: %Ecto.Changeset{}
+  @spec changeset(map() | Ecto.Changeset.t, map()) :: Ecto.Changeset.t
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, @all_fields)
     |> validate_required(@required_fields)
     |> unique_constraint(:user_id_group_id, [:user_id, :group_id])
+  end
+
+  @all_update_fields ~w(is_admin)
+  @required_update_fields [:is_admin]
+
+  @doc """
+  Builds a changeset for use when updating an existing UserGroup entry.
+  
+  Does not allow the modification of the associated user or group.
+  """
+  @spec update_changeset(map() | Ecto.Changeset.t, map()) :: Ecto.Changeset.t
+  def update_changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, @all_update_fields)
+    |> validate_required(@required_update_fields) 
   end
 
   @doc """

--- a/web/models/user_group.ex
+++ b/web/models/user_group.ex
@@ -11,7 +11,7 @@ defmodule Pairmotron.UserGroup do
     belongs_to :user, Pairmotron.User
     belongs_to :group, Pairmotron.Group
 
-    @all_fields ~w(group_id user_id)
+    @all_fields ~w(group_id user_id is_admin)
     @required_fields [:group_id, :user_id]
 
     timestamps()

--- a/web/models/user_group.ex
+++ b/web/models/user_group.ex
@@ -6,6 +6,8 @@ defmodule Pairmotron.UserGroup do
   use Pairmotron.Web, :model
 
   schema "users_groups" do
+    field :is_admin, :boolean
+
     belongs_to :user, Pairmotron.User
     belongs_to :group, Pairmotron.Group
 

--- a/web/router.ex
+++ b/web/router.ex
@@ -60,6 +60,8 @@ defmodule Pairmotron.Router do
     resources "/invitations", UsersGroupMembershipRequestController, only: [:index, :create, :update, :delete]
     resources "/groups", GroupController
     delete "/groups/:group_id/users/:user_id", UserGroupController, :delete
+    get "/groups/:group_id/users/:user_id", UserGroupController, :edit
+    put "/groups/:group_id/users/:user_id", UserGroupController, :update
 
     get "/pair_retros/new/:pair_id", PairRetroController, :new
     resources "/pair_retros", PairRetroController, except: [:new]

--- a/web/templates/group/show.html.eex
+++ b/web/templates/group/show.html.eex
@@ -31,6 +31,11 @@
         <td>
           <%= format_boolean(user.active) %>
         </td>
+        <td>
+          <%= if current_user_is_owner_or_admin_of_group?(@conn, @group, @user_group) do %> 
+            <%= link "Edit Membership", to: user_group_path(@conn, :edit, @group, user) %>
+          <%= end %>
+        </td>
       </tr>
     <% end %>
   </tbody>

--- a/web/templates/user_group/edit.html.eex
+++ b/web/templates/user_group/edit.html.eex
@@ -1,0 +1,6 @@
+<h2><%= "Edit #{@user_group.user.name}'s membership in #{@user_group.group.name}" %></h2>
+
+<%= render "form.html", changeset: @changeset,
+                        action: user_group_path(@conn, :update, @user_group.group, @user_group.user) %>
+
+<%= link "Back to Group", to: group_path(@conn, :show, @user_group.group) %>

--- a/web/templates/user_group/edit.html.eex
+++ b/web/templates/user_group/edit.html.eex
@@ -3,4 +3,5 @@
 <%= render "form.html", changeset: @changeset,
                         action: user_group_path(@conn, :update, @user_group.group, @user_group.user) %>
 
-<%= link "Back to Group", to: group_path(@conn, :show, @user_group.group) %>
+<% delete_alert = "Are you sure you want to remove #{@user_group.user.name} from the #{@user_group.group.name} group?" %>
+<%= link "Remove from group", to: user_group_path(@conn, :delete, @user_group.group, @user_group.user), method: :delete, class: "btn btn-danger", data: [confirm: delete_alert] %>

--- a/web/templates/user_group/form.html.eex
+++ b/web/templates/user_group/form.html.eex
@@ -12,6 +12,6 @@
   </div>
 
   <div class="form-group">
-    <%= submit "Submit", class: "btn btn-primary" %>
+    <%= submit "Save", class: "btn btn-primary" %>
   </div>
 <% end %>

--- a/web/templates/user_group/form.html.eex
+++ b/web/templates/user_group/form.html.eex
@@ -1,0 +1,17 @@
+<%= form_for @changeset, @action, fn f -> %>
+  <%= if @changeset.action do %>
+    <div class="alert alert-danger">
+      <p>Oops, something went wrong! Please check the errors below.</p>
+    </div>
+  <% end %>
+
+  <div class="form-group">
+    <%= label f, :is_admin, class: "control-label" %>
+    <%= checkbox f, :is_admin, class: "form-control" %>
+    <%= error_tag f, :is_admin %>
+  </div>
+
+  <div class="form-group">
+    <%= submit "Submit", class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/web/views/group_view.ex
+++ b/web/views/group_view.ex
@@ -8,6 +8,14 @@ defmodule Pairmotron.GroupView do
     user.id == group.owner_id or user.is_admin
   end
 
+  @spec current_user_is_owner_or_admin_of_group?(Plug.Conn.t, Types.group, Types.user_group) :: boolean()
+  def current_user_is_owner_or_admin_of_group?(%{assigns: %{current_user: user}}, group, nil) do
+    user.id == group.owner_id or user.is_admin
+  end
+  def current_user_is_owner_or_admin_of_group?(%{assigns: %{current_user: user}}, group, user_group) do
+    user.id == group.owner_id or user_group.is_admin or user.is_admin
+  end
+
   @spec current_user_in_group?(%Plug.Conn{}, Types.group) :: boolean()
   def current_user_in_group?(conn, group) do
     conn.assigns.current_user.groups

--- a/web/views/user_group_view.ex
+++ b/web/views/user_group_view.ex
@@ -1,0 +1,4 @@
+defmodule Pairmotron.UserGroupView do
+  @moduledoc false
+  use Pairmotron.Web, :view
+end


### PR DESCRIPTION
Adds an is_admin field to the UserGroup schema. Right now this functionality is pretty limited as additional functionality will be added in other cards.

Allows the owner of a group (or other admins) to make members of a group admin's as well.

Adds the edit and update actions to the UserGroupController, which govern modifying a user's membership in a group (currently only able to alter a user's is_admin property).

The edit form also has a link to removing a user from the group, but currently only the owner can do so (not group admins).

Closes #149 