### PR TITLE
Allow group admins to edit groups and modify group invitations

### DIFF
--- a/lib/abilities.ex
+++ b/lib/abilities.ex
@@ -1,5 +1,5 @@
 defimpl Canada.Can, for: Pairmotron.User do
-  alias Pairmotron.{Group, PairRetro, Project, Types, User}
+  alias Pairmotron.{Group, PairRetro, Project, Repo, Types, User, UserGroup}
 
   @spec can?(Types.user, atom(), struct()) :: boolean()
   def can?(%User{is_admin: true}, _, _), do: true
@@ -9,6 +9,14 @@ defimpl Canada.Can, for: Pairmotron.User do
 
   def can?(%User{id: user_id}, action, %Group{owner_id: user_id})
     when action in [:edit, :update, :delete], do: true
+
+  def can?(%User{id: user_id}, action, %Group{id: group_id})
+    when action in [:edit, :update] do
+    case user_id |> UserGroup.user_group_for_user_and_group(group_id) |> Repo.one do
+      nil -> false
+      user_group -> user_group.is_admin
+    end
+  end
 
   def can?(%User{id: user_id}, :show, project = %Project{group_id: nil}) do
     project = project |> Pairmotron.Repo.preload([{:pair_retros, :user}])

--- a/lib/pairmotron/invite_delete_helper.ex
+++ b/lib/pairmotron/invite_delete_helper.ex
@@ -12,11 +12,11 @@ defmodule Pairmotron.InviteDeleteHelper do
   UsersGroupMembershipRequestController and the GroupInvitationController,
   since the logic is identical, except for the redirect path.
   """
-  @spec delete_invite(Plug.Conn.t, Types.group_membership_request, binary()) :: Plug.Conn.t
-  def delete_invite(conn, group_membership_request, redirect_path) do
+  @spec delete_invite(Plug.Conn.t, Types.group_membership_request, binary(), Types.user_group | nil) :: Plug.Conn.t
+  def delete_invite(conn, group_membership_request, redirect_path, user_group) do
     current_user = conn.assigns.current_user
 
-    if user_can_delete_invite(current_user, group_membership_request) do
+    if user_can_delete_invite(current_user, group_membership_request, user_group) do
       Repo.delete!(group_membership_request)
       conn
       |> put_flash(:info, "Group Invite deleted successfully.")
@@ -33,8 +33,11 @@ defmodule Pairmotron.InviteDeleteHelper do
     |> redirect(to: redirect_path)
   end
 
-  @spec user_can_delete_invite(Types.user, Types.group_membership_request) :: boolean()
-  defp user_can_delete_invite(user, group_membership_request) do
+  @spec user_can_delete_invite(Types.user, Types.group_membership_request, Types.user_group | nil) :: boolean()
+  defp user_can_delete_invite(user, group_membership_request, nil) do
     user.id in [group_membership_request.user_id, group_membership_request.group.owner_id]
+  end
+  defp user_can_delete_invite(user, group_membership_request, user_group) do
+    user.id in [group_membership_request.user_id, group_membership_request.group.owner_id] or user_group.is_admin
   end
 end

--- a/test/controllers/group_controller_test.exs
+++ b/test/controllers/group_controller_test.exs
@@ -33,6 +33,25 @@ defmodule Pairmotron.GroupControllerTest do
       refute html_response(conn, 200) =~ group_invitation_path(conn, :index, group)
     end
 
+    test "shows group invitations link if user is group owner", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{owner: user})
+      conn = get conn, group_path(conn, :index)
+      assert html_response(conn, 200) =~ group_invitation_path(conn, :index, group)
+    end
+
+    test "shows group invitations link if user is group admin", %{conn: conn, logged_in_user: user} do
+      group = insert(:group)
+      insert(:user_group, %{user: user, group: group, is_admin: true})
+      conn = get conn, group_path(conn, :index)
+      assert html_response(conn, 200) =~ group_invitation_path(conn, :index, group)
+    end
+
+    test "does not show group invitations link if user is group owner or admin", %{conn: conn, logged_in_user: user} do
+      group = insert(:group)
+      conn = get conn, group_path(conn, :index)
+      refute html_response(conn, 200) =~ group_invitation_path(conn, :index, group)
+    end
+
     test "shows edit group link if user is group owner", %{conn: conn, logged_in_user: user} do
       group = insert(:group, %{owner: user})
       conn = get conn, group_path(conn, :index)
@@ -49,7 +68,6 @@ defmodule Pairmotron.GroupControllerTest do
     test "does not show edit group link if user is not group owner", %{conn: conn} do
       group = insert(:group)
       conn = get conn, group_path(conn, :index)
-      refute html_response(conn, 200) =~ "Edit"
       refute html_response(conn, 200) =~ group_path(conn, :edit, group)
     end
 
@@ -168,7 +186,20 @@ defmodule Pairmotron.GroupControllerTest do
       assert html_response(conn, 200) =~ group.name
     end
 
-    test "does not show invitations link if user is not group owner", %{conn: conn} do
+    test "shows group invitations link if user is group owner", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{owner: user})
+      conn = get conn, group_path(conn, :show, group)
+      assert html_response(conn, 200) =~ group_invitation_path(conn, :index, group)
+    end
+
+    test "shows group invitations link if user is group admin", %{conn: conn, logged_in_user: user} do
+      group = insert(:group)
+      insert(:user_group, %{user: user, group: group, is_admin: true})
+      conn = get conn, group_path(conn, :show, group)
+      assert html_response(conn, 200) =~ group_invitation_path(conn, :index, group)
+    end
+
+    test "does not show group invitations link if user is group owner or admin", %{conn: conn, logged_in_user: user} do
       group = insert(:group)
       conn = get conn, group_path(conn, :show, group)
       refute html_response(conn, 200) =~ group_invitation_path(conn, :index, group)
@@ -214,7 +245,6 @@ defmodule Pairmotron.GroupControllerTest do
     test "shows edit link when user is group owner", %{conn: conn, logged_in_user: user} do
       group = insert(:group, %{owner: user, users: [user]})
       conn = get conn, group_path(conn, :show, group)
-      assert html_response(conn, 200) =~ "Edit"
       assert html_response(conn, 200) =~ group_path(conn, :edit, group)
     end
 

--- a/test/controllers/group_controller_test.exs
+++ b/test/controllers/group_controller_test.exs
@@ -33,6 +33,19 @@ defmodule Pairmotron.GroupControllerTest do
       refute html_response(conn, 200) =~ group_invitation_path(conn, :index, group)
     end
 
+    test "shows edit group link if user is group owner", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{owner: user})
+      conn = get conn, group_path(conn, :index)
+      assert html_response(conn, 200) =~ group_path(conn, :edit, group)
+    end
+
+    test "shows edit group link if user is group admin", %{conn: conn, logged_in_user: user} do
+      group = insert(:group)
+      insert(:user_group, %{user: user, group: group, is_admin: true})
+      conn = get conn, group_path(conn, :index)
+      assert html_response(conn, 200) =~ group_path(conn, :edit, group)
+    end
+
     test "does not show edit group link if user is not group owner", %{conn: conn} do
       group = insert(:group)
       conn = get conn, group_path(conn, :index)
@@ -167,10 +180,22 @@ defmodule Pairmotron.GroupControllerTest do
       refute html_response(conn, 200) =~ group_invitation_path(conn, :index, group)
     end
 
+    test "shows link to edit group if user is group owner", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{owner: user})
+      conn = get conn, group_path(conn, :show, group)
+      assert html_response(conn, 200) =~ group_path(conn, :edit, group)
+    end
+
+    test "shows link to edit group if user is group admin", %{conn: conn, logged_in_user: user} do
+      group = insert(:group)
+      insert(:user_group, %{user: user, group: group, is_admin: true})
+      conn = get conn, group_path(conn, :show, group)
+      assert html_response(conn, 200) =~ group_path(conn, :edit, group)
+    end
+
     test "does not show edit group link if user is not group owner", %{conn: conn} do
       group = insert(:group)
       conn = get conn, group_path(conn, :show, group)
-      refute html_response(conn, 200) =~ "Edit"
       refute html_response(conn, 200) =~ group_path(conn, :edit, group)
     end
 

--- a/test/controllers/group_controller_test.exs
+++ b/test/controllers/group_controller_test.exs
@@ -46,7 +46,7 @@ defmodule Pairmotron.GroupControllerTest do
       assert html_response(conn, 200) =~ group_invitation_path(conn, :index, group)
     end
 
-    test "does not show group invitations link if user is group owner or admin", %{conn: conn, logged_in_user: user} do
+    test "does not show group invitations link if user is group owner or admin", %{conn: conn} do
       group = insert(:group)
       conn = get conn, group_path(conn, :index)
       refute html_response(conn, 200) =~ group_invitation_path(conn, :index, group)
@@ -199,7 +199,7 @@ defmodule Pairmotron.GroupControllerTest do
       assert html_response(conn, 200) =~ group_invitation_path(conn, :index, group)
     end
 
-    test "does not show group invitations link if user is group owner or admin", %{conn: conn, logged_in_user: user} do
+    test "does not show group invitations link if user is group owner or admin", %{conn: conn} do
       group = insert(:group)
       conn = get conn, group_path(conn, :show, group)
       refute html_response(conn, 200) =~ group_invitation_path(conn, :index, group)

--- a/test/controllers/group_controller_test.exs
+++ b/test/controllers/group_controller_test.exs
@@ -297,6 +297,13 @@ defmodule Pairmotron.GroupControllerTest do
       assert html_response(conn, 200) =~ "Edit group"
     end
 
+    test "renders form form if user is group admin", %{conn: conn, logged_in_user: user} do
+      group = insert(:group)
+      insert(:user_group, %{user: user, group: group, is_admin: true})
+      conn = get conn, group_path(conn, :edit, group)
+      assert html_response(conn, 200) =~ "Edit group"
+    end
+
     test "does not allow editing a group not owned by logged in user", %{conn: conn} do
       group = insert(:group)
       conn = get conn, group_path(conn, :edit, group)

--- a/test/controllers/profile_controller_test.exs
+++ b/test/controllers/profile_controller_test.exs
@@ -42,10 +42,29 @@ defmodule Pairmotron.ProfileControllerTest do
       assert html_response(conn, 200) =~ "Find a group"
     end
 
-    test "links to group edit if current user is owner", %{conn: conn, logged_in_user: user} do
-      group1 = insert(:group, %{owner: user, users: [user]})
+    test "links to group invitations if current user is owner", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{owner: user, users: [user]})
       conn = get conn, profile_path(conn, :show)
-      assert html_response(conn, 200) =~ group_path(conn, :edit, group1)
+      assert html_response(conn, 200) =~ group_invitation_path(conn, :index, group)
+    end
+
+    test "links to group invitations if current user is group admin", %{conn: conn, logged_in_user: user} do
+      group = insert(:group)
+      insert(:user_group, %{user: user, group: group, is_admin: true})
+      conn = get conn, profile_path(conn, :show)
+      assert html_response(conn, 200) =~ group_invitation_path(conn, :index, group)
+    end
+
+    test "does not link to group invitations if current user is not owner or admin", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{users: [user]})
+      conn = get conn, profile_path(conn, :show)
+      refute html_response(conn, 200) =~ group_invitation_path(conn, :index, group)
+    end
+
+    test "links to group edit if current user is owner", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{owner: user, users: [user]})
+      conn = get conn, profile_path(conn, :show)
+      assert html_response(conn, 200) =~ group_path(conn, :edit, group)
     end
 
     test "links to group edit if current user is group admin", %{conn: conn, logged_in_user: user} do
@@ -55,10 +74,10 @@ defmodule Pairmotron.ProfileControllerTest do
       assert html_response(conn, 200) =~ group_path(conn, :edit, group)
     end
 
-    test "doesn't link to group edit if current user is not owner", %{conn: conn, logged_in_user: user} do
-      group1 = insert(:group, %{users: [user]})
+    test "doesn't link to group edit if current user is not owner or admin", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{users: [user]})
       conn = get conn, profile_path(conn, :show)
-      refute html_response(conn, 200) =~ group_path(conn, :edit, group1)
+      refute html_response(conn, 200) =~ group_path(conn, :edit, group)
     end
   end
 

--- a/test/controllers/profile_controller_test.exs
+++ b/test/controllers/profile_controller_test.exs
@@ -45,8 +45,14 @@ defmodule Pairmotron.ProfileControllerTest do
     test "links to group edit if current user is owner", %{conn: conn, logged_in_user: user} do
       group1 = insert(:group, %{owner: user, users: [user]})
       conn = get conn, profile_path(conn, :show)
-      assert html_response(conn, 200) =~ "Edit"
       assert html_response(conn, 200) =~ group_path(conn, :edit, group1)
+    end
+
+    test "links to group edit if current user is group admin", %{conn: conn, logged_in_user: user} do
+      group = insert(:group)
+      insert(:user_group, %{user: user, group: group, is_admin: true})
+      conn = get conn, profile_path(conn, :show)
+      assert html_response(conn, 200) =~ group_path(conn, :edit, group)
     end
 
     test "doesn't link to group edit if current user is not owner", %{conn: conn, logged_in_user: user} do

--- a/test/models/user_group_test.exs
+++ b/test/models/user_group_test.exs
@@ -76,4 +76,24 @@ defmodule Pairmotron.UserGroupTest do
       assert is_nil(user_group)
     end
   end
+
+  describe "user_groups_for_user_and_group/1" do
+    test "returns user_group with :user and :group preloaded" do
+      user = insert(:user)
+      insert(:group, %{users: [user]})
+      [user_group] = UserGroup.user_groups_for_user_with_group(user.id) |> Repo.all
+      assert Ecto.assoc_loaded?(user_group.user)
+      assert Ecto.assoc_loaded?(user_group.group)
+    end
+
+    test "returns [] if user is not in a group" do
+      user = insert(:user)
+      insert(:group)
+      assert [] = UserGroup.user_groups_for_user_with_group(user.id) |> Repo.all
+    end
+
+    test "returns [] if user does not exist" do
+      assert [] = UserGroup.user_groups_for_user_with_group(123) |> Repo.all
+    end
+  end
 end

--- a/test/views/group_view_test.exs
+++ b/test/views/group_view_test.exs
@@ -2,14 +2,35 @@ defmodule Pairmotron.GroupViewTest do
   use Pairmotron.ConnCase, async: true
   alias Pairmotron.GroupView
 
-  test "truncate/2 does nothing to a string shorted than the length" do
-    assert GroupView.truncate("short string", 20) == "short string"
+  describe "truncate/2" do
+    test "does nothing to a string shorted than the length" do
+      assert GroupView.truncate("short string", 20) == "short string"
+    end
+    test "shortens and adds ellipses to long strings" do
+      assert GroupView.truncate("long string", 6) == "long s..."
+    end
+    test "ignores nil" do
+      assert GroupView.truncate(nil, 5) == nil
+    end
   end
-  test "truncate/2 shortens and adds ellipses to long strings" do
-    assert GroupView.truncate("long string", 6) == "long s..."
-  end
-  test "truncate/2 ignores nil" do
-    assert GroupView.truncate(nil, 5) == nil
+
+  describe "user_group_associated_with_group/2)" do
+    test "returns the matching user_group" do
+      group = insert(:group)
+      user_group1 = insert(:user_group)
+      user_group2 = insert(:user_group, %{group: group})
+      assert user_group2.id == GroupView.user_group_associated_with_group(group, [user_group1, user_group2]).id
+    end
+
+    test "returns nil when passed a nil group" do
+      assert nil == GroupView.user_group_associated_with_group(nil, [])
+    end
+
+    test "returns nil when no user_group is associated with list" do
+      group = insert(:group)
+      user_group = insert(:user_group)
+      assert nil == GroupView.user_group_associated_with_group(group, [user_group])
+    end
   end
 end
 

--- a/web/controllers/group_controller.ex
+++ b/web/controllers/group_controller.ex
@@ -11,10 +11,11 @@ defmodule Pairmotron.GroupController do
 
   @spec index(%Plug.Conn{}, map()) :: %Plug.Conn{}
   def index(conn, _params) do
-    groups = Group |> order_by(:name) |> Repo.all
     current_user = conn.assigns.current_user |> Repo.preload([:groups, :group_membership_requests])
+    groups = Group |> order_by(:name) |> Repo.all
+    user_groups = UserGroup.user_groups_for_user_with_group(current_user.id) |> Repo.all
     conn = conn |> Plug.Conn.assign(:current_user, current_user)
-    render(conn, "index.html", groups: groups)
+    render(conn, "index.html", groups: groups, user_groups: user_groups)
   end
 
   @spec new(%Plug.Conn{}, map()) :: %Plug.Conn{}

--- a/web/controllers/group_controller.ex
+++ b/web/controllers/group_controller.ex
@@ -13,7 +13,7 @@ defmodule Pairmotron.GroupController do
   def index(conn, _params) do
     current_user = conn.assigns.current_user |> Repo.preload([:groups, :group_membership_requests])
     groups = Group |> order_by(:name) |> Repo.all
-    user_groups = UserGroup.user_groups_for_user_with_group(current_user.id) |> Repo.all
+    user_groups = current_user.id |> UserGroup.user_groups_for_user_with_group |> Repo.all
     conn = conn |> Plug.Conn.assign(:current_user, current_user)
     render(conn, "index.html", groups: groups, user_groups: user_groups)
   end

--- a/web/controllers/profile_controller.ex
+++ b/web/controllers/profile_controller.ex
@@ -9,7 +9,7 @@ defmodule Pairmotron.ProfileController do
   @spec show(%Plug.Conn{}, map()) :: %Plug.Conn{}
   def show(conn, _params) do
     current_user = conn.assigns.current_user |> Repo.preload([:groups, :group_membership_requests])
-    user_groups = UserGroup.user_groups_for_user_with_group(current_user.id) |> Repo.all
+    user_groups = current_user.id |> UserGroup.user_groups_for_user_with_group |> Repo.all
     conn = conn |> Plug.Conn.assign(:current_user, current_user)
     render(conn, "show.html", user: current_user, user_groups: user_groups)
   end

--- a/web/controllers/profile_controller.ex
+++ b/web/controllers/profile_controller.ex
@@ -4,13 +4,14 @@ defmodule Pairmotron.ProfileController do
   """
   use Pairmotron.Web, :controller
 
-  alias Pairmotron.User
+  alias Pairmotron.{User, UserGroup}
 
   @spec show(%Plug.Conn{}, map()) :: %Plug.Conn{}
   def show(conn, _params) do
     current_user = conn.assigns.current_user |> Repo.preload([:groups, :group_membership_requests])
+    user_groups = UserGroup.user_groups_for_user_with_group(current_user.id) |> Repo.all
     conn = conn |> Plug.Conn.assign(:current_user, current_user)
-    render(conn, "show.html", user: current_user)
+    render(conn, "show.html", user: current_user, user_groups: user_groups)
   end
 
   @spec edit(%Plug.Conn{}, map()) :: %Plug.Conn{}

--- a/web/controllers/users_group_membership_request_controller.ex
+++ b/web/controllers/users_group_membership_request_controller.ex
@@ -94,7 +94,7 @@ defmodule Pairmotron.UsersGroupMembershipRequestController do
   def delete(conn, %{"id" => id}) do
     group_membership_request = GroupMembershipRequest |> Repo.get!(id) |> Repo.preload(:group)
     redirect_path = users_group_membership_request_path(conn, :index)
-    InviteDeleteHelper.delete_invite(conn, group_membership_request, redirect_path)
+    InviteDeleteHelper.delete_invite(conn, group_membership_request, redirect_path, nil)
   end
 
   @spec user_is_in_group?(Types.user, group_id :: integer() | binary()) :: boolean()

--- a/web/models/user_group.ex
+++ b/web/models/user_group.ex
@@ -33,14 +33,14 @@ defmodule Pairmotron.UserGroup do
 
   @doc """
   Builds a changeset for use when updating an existing UserGroup entry.
-  
+
   Does not allow the modification of the associated user or group.
   """
   @spec update_changeset(map() | Ecto.Changeset.t, map()) :: Ecto.Changeset.t
   def update_changeset(struct, params \\ %{}) do
     struct
     |> cast(params, @all_update_fields)
-    |> validate_required(@required_update_fields) 
+    |> validate_required(@required_update_fields)
   end
 
   @doc """
@@ -54,6 +54,19 @@ defmodule Pairmotron.UserGroup do
     join: group in assoc(user_group, :group),
     where: user.id == ^user_id,
     where: group.id == ^group_id,
+    preload: [user: user, group: group]
+  end
+
+  @doc """
+  Returns a query to retrieve all of a users UserGroups with the :user and
+  :group associations preloaded.
+  """
+  @spec user_groups_for_user_with_group(integer() | binary()) :: Ecto.Query.t
+  def user_groups_for_user_with_group(user_id) do
+    from user_groups in Pairmotron.UserGroup,
+    join: user in assoc(user_groups, :user),
+    join: group in assoc(user_groups, :group),
+    where: user.id == ^user_id,
     preload: [user: user, group: group]
   end
 end

--- a/web/templates/group/group_actions.html.eex
+++ b/web/templates/group/group_actions.html.eex
@@ -14,7 +14,7 @@
     <%= true -> %>
   <%= end %>
 
-  <%= if current_user_can_edit_group?(@conn, @group) do %>
+  <%= if current_user_is_owner_or_admin_of_group?(@conn, @group, @user_group) do %>
     <a href=<%= group_invitation_path(@conn, :index, @group) %>>
       <button class="btn btn-primary btn-sm">Invitations</button>
     </a>

--- a/web/templates/group/index.html.eex
+++ b/web/templates/group/index.html.eex
@@ -19,7 +19,7 @@
             </small>
           </h4>
           <p><%= truncate(group.description, 110) %></p>
-          <%= render "group_actions.html", conn: @conn, group: group %>
+          <%= render "group_actions.html", conn: @conn, group: group, user_group: user_group_associated_with_group(group, @user_groups) %>
         </li>
       <% end %>
     </ul>

--- a/web/templates/group/show.html.eex
+++ b/web/templates/group/show.html.eex
@@ -12,7 +12,7 @@
   </small>
 </h2>
 <p><%= @group.description %></p>
-<%= render "group_actions.html", conn: @conn, group: @group %>
+<%= render "group_actions.html", conn: @conn, group: @group , user_group: @user_group%>
 <h2>Members</h2>
 <table class="table">
   <thead>

--- a/web/templates/profile/show.html.eex
+++ b/web/templates/profile/show.html.eex
@@ -27,7 +27,7 @@
     <%= for group <- @user.groups do %>
       <li class="list-group-item">
         <h4><%= group.name %></h4>
-        <%= render Pairmotron.GroupView, "group_actions.html", conn: @conn, group: group %>
+        <%= render Pairmotron.GroupView, "group_actions.html", conn: @conn, group: group, user_group: Pairmotron.GroupView.user_group_associated_with_group(group, @user_groups) %>
       </li>
     <% end %>
     <%= if Enum.empty?(@user.groups) do %>

--- a/web/views/group_view.ex
+++ b/web/views/group_view.ex
@@ -49,4 +49,14 @@ defmodule Pairmotron.GroupView do
       string
     end
   end
+
+  @doc """
+  Returns the user_group in the list of user_groups passed in whose group_id
+  matches the passed in group. If there is no associated user_group associaed
+  with the passed in group, then nil is returned
+  """
+  @spec user_group_associated_with_group(Types.group, [Types.user_group]) :: Types.user_group | nil
+  def user_group_associated_with_group(group, user_groups) do
+    Enum.find(user_groups, &(&1.group_id == group.id))
+  end
 end


### PR DESCRIPTION
Gives group admins access to the GroupController :edit and :update actions, as well as the GroupInvitationController :index, :new, :create, :update, and :delete actions.

Makes the "Invitations" and "Edit" links for the group_actions template visible for group admins in addition to group owners.

Closes #153 
Closes #154 