### PR TITLE
Add docker support for development and testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ addons:
   - postgresql: '9.5'
 env:
   - MIX_ENV=test
-  - DB_ENV_POSTGRES_USER=postgres
+  - PG_USER=postgres
 install:
   - mix local.hex --force
   - mix local.rebar --force

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ addons:
   - postgresql: '9.5'
 env:
   - MIX_ENV=test
-  - PG_USER=postgres
+  - DB_ENV_POSTGRES_USER=postgres
 install:
   - mix local.hex --force
   - mix local.rebar --force

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM elixir:1.4.4
+
+RUN mix local.hex --force
+RUN mix local.rebar --force
+RUN mix archive.install --force https://github.com/phoenixframework/archives/raw/master/phoenix_new.ez
+
+WORKDIR /app
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,7 @@ RUN mix local.hex --force
 RUN mix local.rebar --force
 RUN mix archive.install --force https://github.com/phoenixframework/archives/raw/master/phoenix_new.ez
 
-WORKDIR /app
+RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
+RUN apt-get install -y -q nodejs
+
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ Pairmotron is an app powered by [Phoenix](http://www.phoenixframework.org/) that
   * Setup environment variables for your PostgreSQL user (PG_USER) and password (PG_PASSWORD)
     * On Mac or Linux add this to your .bashrc or .zshrc:
 ```
-export DB_ENV_POSTGRES_USER="example_username"
-export DB_ENV_POSTGRES_PASSWORD="example_password"
+export PG_USER="example_username"
+export PG_PASSWORD="example_password"
+export PG_HOST="localhost"
 ```
   * Create and migrate your database with `mix ecto.create && mix ecto.migrate`
   * Install Node.js dependencies with `npm install`

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Pairmotron is an app powered by [Phoenix](http://www.phoenixframework.org/) that randomly pairs up users within groups on a weekly basis to work on a project or just write some code!
 
-## Installation
+## Local Installation
 
 ### Prerequisites
 
@@ -17,16 +17,35 @@ Pairmotron is an app powered by [Phoenix](http://www.phoenixframework.org/) that
   * Setup environment variables for your PostgreSQL user (PG_USER) and password (PG_PASSWORD)
     * On Mac or Linux add this to your .bashrc or .zshrc:
 ```
-export PG_USER="example_username"
-export PG_PASSWORD="example_password"
+export DB_ENV_POSTGRES_USER="example_username"
+export DB_ENV_POSTGRES_PASSWORD="example_password"
 ```
   * Create and migrate your database with `mix ecto.create && mix ecto.migrate`
   * Install Node.js dependencies with `npm install`
   * Start Phoenix endpoint with `mix phoenix.server`
 
+##Developing and Testing with Docker
+
+Using this model of development allows you to not install anything other
+than docker.
+
+### Running it
+  * docker-compose up -d web
+  * docker-compose run web mix deps.get
+  * docker-compose run web mix ecto.create && mix ecto.migrate
+  * docker-compose restart web
+
+## Check it out in a browser
+
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
 
+## Deploy to Production
 Ready to run in production? 
 * Please [check the phoenix deployment guides](http://www.phoenixframework.org/docs/deployment).
 * Set the environment variable (SECRET_KEY_BASE) used for session cookies.
 * Set the environment variable (GUARDIAN_JWK_KEY) for the secret key which guardian uses for JWT tokens.
+
+## Run the Tests in Docker
+  * docker-compose run test
+### Only a specific Test file
+  * docker-compose run test mix test/controllers/group_controller_test.exs

--- a/README.md
+++ b/README.md
@@ -31,14 +31,16 @@ than docker.
 
 ### Running it
   * docker-compose up -d web
-  * docker-compose run web mix deps.get
-  * docker-compose run web mix ecto.create && mix ecto.migrate
+  * docker-compose exec web mix deps.get
+  * docker-compose exec web mix ecto.create 
+  * docker-compose exec web mix ecto.migrate
+  * docker-compose exec web npm install
   * docker-compose restart web
 
 ### Run the Tests in Docker
-  * docker-compose run test
+  * docker-compose run -e "MIX_ENV=test" web mix test 
   * Only test a specific test file
-    * docker-compose run test mix test/controllers/group_controller_test.exs
+    * docker-compose run -e "MIX_ENV=test" web mix test/controllers/group_controller_test.exs
   
 ## Check it out in a browser
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ export DB_ENV_POSTGRES_PASSWORD="example_password"
   * Install Node.js dependencies with `npm install`
   * Start Phoenix endpoint with `mix phoenix.server`
 
-##Developing and Testing with Docker
+## Developing and Testing with Docker
 
 Using this model of development allows you to not install anything other
 than docker.
@@ -35,6 +35,11 @@ than docker.
   * docker-compose run web mix ecto.create && mix ecto.migrate
   * docker-compose restart web
 
+### Run the Tests in Docker
+  * docker-compose run test
+  * Only test a specific test file
+    * docker-compose run test mix test/controllers/group_controller_test.exs
+  
 ## Check it out in a browser
 
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
@@ -45,7 +50,4 @@ Ready to run in production?
 * Set the environment variable (SECRET_KEY_BASE) used for session cookies.
 * Set the environment variable (GUARDIAN_JWK_KEY) for the secret key which guardian uses for JWT tokens.
 
-## Run the Tests in Docker
-  * docker-compose run test
-### Only a specific Test file
-  * docker-compose run test mix test/controllers/group_controller_test.exs
+

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -36,9 +36,9 @@ config :phoenix, :stacktrace_depth, 20
 # Configure your database
 config :pairmotron, Pairmotron.Repo,
   adapter: Ecto.Adapters.Postgres,
-  username: System.get_env("DB_ENV_POSTGRES_USER"),
-  password: System.get_env("DB_ENV_POSTGRES_PASSWORD"),
+  username: System.get_env("PG_USER"),
+  password: System.get_env("PG_PASSWORD"),
   database: "pairmotron_dev",
-  hostname: System.get_env("DB_ENV_POSTGRES_HOST"),
+  hostname: System.get_env("PG_HOST"),
   pool_size: 10
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -36,8 +36,9 @@ config :phoenix, :stacktrace_depth, 20
 # Configure your database
 config :pairmotron, Pairmotron.Repo,
   adapter: Ecto.Adapters.Postgres,
-  username: System.get_env("PG_USER"),
-  password: System.get_env("PG_PASSWORD"),
+  username: System.get_env("DB_ENV_POSTGRES_USER"),
+  password: System.get_env("DB_ENV_POSTGRES_PASSWORD"),
   database: "pairmotron_dev",
-  hostname: "localhost",
+  hostname: System.get_env("DB_ENV_POSTGRES_HOST"),
   pool_size: 10
+

--- a/config/test.exs
+++ b/config/test.exs
@@ -12,10 +12,10 @@ config :logger, level: :warn
 # Configure your database
 config :pairmotron, Pairmotron.Repo,
   adapter: Ecto.Adapters.Postgres,
-  username: System.get_env("DB_ENV_POSTGRES_USER"),
-  password: System.get_env("DB_ENV_POSTGRES_PASSWORD"),
+  username: System.get_env("PG_USER"),
+  password: System.get_env("PG_PASSWORD"),
   database: "pairmotron_test",
-  hostname: System.get_env("DB_ENV_POSTGRES_HOST"),
+  hostname: System.get_env("PG_HOST"),
   pool: Ecto.Adapters.SQL.Sandbox
 
 config :pairmotron, Pairmotron.Mailer,

--- a/config/test.exs
+++ b/config/test.exs
@@ -12,8 +12,9 @@ config :logger, level: :warn
 # Configure your database
 config :pairmotron, Pairmotron.Repo,
   adapter: Ecto.Adapters.Postgres,
-  username: System.get_env("PG_USER"),
-  password: System.get_env("PG_PASSWORD"),
+  username: System.get_env("DB_ENV_POSTGRES_USER"),
+  password: System.get_env("DB_ENV_POSTGRES_PASSWORD"),
   database: "pairmotron_test",
-  hostname: "localhost",
+  hostname: System.get_env("DB_ENV_POSTGRES_HOST"),
   pool: Ecto.Adapters.SQL.Sandbox
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - POSTGRES_HOST=db
   test:
     #this is foldername (default projectName) _web
-    image: testpair_web
+    image: ${COMPOSE_PROJECT_NAME}_web
     command: mix test
     environment:
       - MIX_ENV=test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,36 +1,19 @@
-version: "2.1"
-
-services:
-  web:
-    build: .
-    ports:
-      - "4000:4000"
-    command: bash -c "npm install && mix phoenix.server"
-    environment:
-      - MIX_ENV=dev
-      - PORT=4000
-    volumes:
-      - .:/app
-    working_dir: /app
-    links:
-      - db
-    depends_on:
-      - db
-  db:
-    image: postgres:9.5
-    environment:
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=postgres
-      - POSTGRES_HOST=db
-  test:
-    #this is foldername (default projectName) _web
-    image: ${COMPOSE_PROJECT_NAME}_web
-    command: mix test
-    environment:
-      - MIX_ENV=test
-    volumes_from:
-      - web
-    links:
-      - db
-    depends_on:
-      - db
+web:
+  build: .
+  ports:
+    - "4000:4000"
+  command: mix phoenix.server
+  environment:
+    - MIX_ENV=dev
+    - PORT=4000
+  volumes:
+    - .:/app
+  working_dir: /app
+  links:
+    - db
+db:
+  image: postgres:9.5
+  environment:
+    - POSTGRES_USER=postgres
+    - POSTGRES_PASSWORD=postgres
+    - POSTGRES_HOST=db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,28 +1,36 @@
-web:
-  build: .
-  ports:
-    - "4000:4000"
-  command: mix phoenix.server
-  environment:
-    - MIX_ENV=dev
-    - PORT=4000
-  volumes:
-    - .:/app
-  links:
-    - db
-db:
-  image: postgres:9.5
-  environment:
-    - POSTGRES_USER=postgres
-    - POSTGRES_PASSWORD=postgres
-    - POSTGRES_HOST=db
-test:
-  #this is foldername (default projectName) _web
-  image: testpair_web
-  command: mix test
-  environment:
-    - MIX_ENV=test
-  volumes_from:
-    - web
-  links:
-    - db
+version: "2.1"
+
+services:
+  web:
+    build: .
+    ports:
+      - "4000:4000"
+    command: bash -c "npm install && mix phoenix.server"
+    environment:
+      - MIX_ENV=dev
+      - PORT=4000
+    volumes:
+      - .:/app
+    working_dir: /app
+    links:
+      - db
+    depends_on:
+      - db
+  db:
+    image: postgres:9.5
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_HOST=db
+  test:
+    #this is foldername (default projectName) _web
+    image: testpair_web
+    command: mix test
+    environment:
+      - MIX_ENV=test
+    volumes_from:
+      - web
+    links:
+      - db
+    depends_on:
+      - db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,9 @@ web:
   environment:
     - MIX_ENV=dev
     - PORT=4000
+    - PG_USER=postgres
+    - PG_PASSWORD=postgres
+    - PG_HOST=db
   volumes:
     - .:/app
   working_dir: /app
@@ -14,6 +17,6 @@ web:
 db:
   image: postgres:9.5
   environment:
-    - POSTGRES_USER=postgres
-    - POSTGRES_PASSWORD=postgres
-    - POSTGRES_HOST=db
+    - PG_USER=postgres
+    - PG_PASSWORD=postgres
+    - PG_HOST=db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+web:
+  build: .
+  ports:
+    - "4000:4000"
+  command: mix phoenix.server
+  environment:
+    - MIX_ENV=dev
+    - PORT=4000
+  volumes:
+    - .:/app
+  links:
+    - db
+db:
+  image: postgres:9.5
+  environment:
+    - POSTGRES_USER=postgres
+    - POSTGRES_PASSWORD=postgres
+    - POSTGRES_HOST=db
+test:
+  #this is foldername (default projectName) _web
+  image: testpair_web
+  command: mix test
+  environment:
+    - MIX_ENV=test
+  volumes_from:
+    - web
+  links:
+    - db


### PR DESCRIPTION
In this pull request, I've added a base elixir image with some minor dependencies.  Then it is wired up using docker-compose in conjunction with a standard postgres:9.5 image.  

I then documented it via the README.  You'll notice I changed the config for the local PG_USER/PASSWORD.  This was to make them the same and accessible via the dev.exs and test.exs.

Hope it helps.