### PR TITLE
Add email for when a user is invited to a group

### DIFF
--- a/lib/mailer/email.ex
+++ b/lib/mailer/email.ex
@@ -47,4 +47,43 @@ defmodule Pairmotron.Email do
   defp reset_path(token_string) do
     password_reset_url(Pairmotron.Endpoint, :edit, token_string)
   end
+
+  @doc """
+  Returns an email ready to be sent by Bamboo to a user instructing them that
+  they have been invited to a group. It contains a link to their invitations
+  page.
+  """
+  @spec group_invitation_email(Types.user, Types.group) :: Bamboo.Email.t
+  def group_invitation_email(user, group) do
+    new_email()
+    |> to(user.email)
+    |> from("no-reply@pairmotron.com")
+    |> subject("Pairmotron Group Invitation")
+    |> html_body(group_invitation_email_html_body(group.name))
+    |> text_body(group_invitation_email_text_body(group.name))
+  end
+
+  @spec group_invitation_email_html_body(String.t) :: String.t
+  defp group_invitation_email_html_body(group_name) do
+  """
+  You have been invited to join the #{group_name} group in Pairmotron!
+  <br><br>
+  <a href=#{invitation_index_path()}>Click here to view your invitations</a>
+  """
+  end
+
+  @spec group_invitation_email_text_body(String.t) :: String.t
+  defp group_invitation_email_text_body(group_name) do
+  """
+  You have been invited to join the #{group_name} group in Pairmotron!
+  \n\n
+  Follow this link to view your invitations: #{invitation_index_path()}
+  """
+  end
+
+  @spec invitation_index_path() :: String.t
+  defp invitation_index_path() do
+    users_group_membership_request_url(Pairmotron.Endpoint, :index)
+  end
+
 end

--- a/test/lib/mailer/email_test.exs
+++ b/test/lib/mailer/email_test.exs
@@ -33,4 +33,42 @@ defmodule Pairmotron.EmailTest do
         password_reset_url(Pairmotron.Endpoint, :edit, token.token)
     end
   end
+
+  describe "group_invitation_email/2" do
+    setup do
+      user = build(:user)
+      group = build(:group)
+      {:ok, [user: user, group: group]}
+    end
+
+    test "returns an email to the user that is passed in", %{user: user, group: group} do
+      assert Email.group_invitation_email(user, group).to == user.email
+    end
+
+    test "returns an email from no-reply@pairmotron.com", %{user: user, group: group} do
+      assert Email.group_invitation_email(user, group).from == "no-reply@pairmotron.com"
+    end
+
+    test "returns an email with a subject of 'Pairmotron Group Invitation", %{user: user, group: group} do
+      assert Email.group_invitation_email(user, group).subject == "Pairmotron Group Invitation"
+    end
+
+    test "returns an email containing the group name in the html_body", %{user: user, group: group} do
+      assert Email.group_invitation_email(user, group).html_body =~ group.name
+    end
+
+    test "returns an email containing the group name in the text_body", %{user: user, group: group} do
+      assert Email.group_invitation_email(user, group).text_body =~ group.name
+    end
+
+    test "returns an email containing a link to the invitations index in html_body", %{user: user, group: group} do
+      assert Email.group_invitation_email(user, group).html_body =~
+        users_group_membership_request_url(Pairmotron.Endpoint, :index)
+    end
+
+    test "returns an email containing a link to the invitations index in text_body", %{user: user, group: group} do
+      assert Email.group_invitation_email(user, group).text_body =~
+        users_group_membership_request_url(Pairmotron.Endpoint, :index)
+    end
+  end
 end

--- a/web/controllers/group_invitation_controller.ex
+++ b/web/controllers/group_invitation_controller.ex
@@ -74,6 +74,8 @@ defmodule Pairmotron.GroupInvitationController do
 
       case Repo.insert(changeset) do
         {:ok, _group_membership_request} ->
+          send_group_invitation_email(user, group)
+
           conn
           |> put_flash(:info, "Successfully invited #{user.name} to join #{group.name}.")
           |> redirect(to: group_invitation_path(conn, :index, group_id))
@@ -84,6 +86,13 @@ defmodule Pairmotron.GroupInvitationController do
     else
       redirect_and_flash_error(conn, "You must be the owner or admin of a group to invite user to that group", group_id)
     end
+  end
+
+  @spec send_group_invitation_email(Types.user, Types.group) :: any
+  defp send_group_invitation_email(user, group) do
+    user
+    |> Pairmotron.Email.group_invitation_email(group)
+    |> Pairmotron.Mailer.deliver_later
   end
 
   @spec invitable_users_for_select(Types.group) :: [{binary(), integer()}]


### PR DESCRIPTION
Send an email to users who have been invited to a group by the group's owner. This email informs them that they have been invited to the group and links them to the listing of their current invitations.

Closes #163 