### PR TITLE
Allow Group Admins to remove users from the group

### DIFF
--- a/test/controllers/user_group_controller_test.exs
+++ b/test/controllers/user_group_controller_test.exs
@@ -179,6 +179,17 @@ defmodule Pairmotron.UserGroupControllerTest do
       refute Repo.get(UserGroup, user_group.id)
     end
 
+    test "deletes user group if logged in user is a group admin", %{conn: conn, logged_in_user: user} do
+      group = insert(:group)
+      insert(:user_group, %{group: group, user: user, is_admin: true})
+      other_user = insert(:user)
+      user_group = insert(:user_group, %{group: group, user: other_user})
+
+      conn = delete conn, user_group_path(conn, :delete, group, other_user)
+      assert redirected_to(conn) == group_path(conn, :show, group)
+      refute Repo.get(UserGroup, user_group.id)
+    end
+
     test "deletes user group and redirects to profile user is owner of group and the user on the user_group",
       %{conn: conn, logged_in_user: user} do
 

--- a/web/controllers/group_invitation_controller.ex
+++ b/web/controllers/group_invitation_controller.ex
@@ -100,6 +100,7 @@ defmodule Pairmotron.GroupInvitationController do
     group
     |> User.users_not_in_group
     |> Repo.all
+    |> Enum.sort(&(String.downcase(&1.name) <= String.downcase(&2.name)))
     |> Enum.map(&["#{&1.name}": &1.id])
     |> List.flatten
   end


### PR DESCRIPTION
Gives group-specific admins the ability to remove all other members from the group. This actually includes the owner, but since the owner retains control of the group even when they're not in it, they can just add themselves back in, so I don't think that this is an issue for this card.

Closes #151