### PR TITLE
Allow group_membership_requests to be accepted in admin

### DIFF
--- a/web/controllers/admin/invitation_accept_controller.ex
+++ b/web/controllers/admin/invitation_accept_controller.ex
@@ -1,0 +1,70 @@
+defmodule Pairmotron.AdminInvitationAcceptController do
+  use Pairmotron.Web, :controller
+
+  alias Pairmotron.{Group, GroupMembershipRequest, User, UserGroup}
+
+  @spec update(Plug.Conn.t, map()) :: Plug.Conn.t
+  def update(conn, %{"user_id" => user_id, "group_membership_request_id" => group_membership_request_id}) do
+    result = with {:ok, user} <- retrieve_user(user_id),
+                  {:ok, group_membership_request} <- retrieve_group_membership_request(group_membership_request_id),
+                  do: delete_invite_and_add_user_to_group(user, group_membership_request)
+
+    case result do
+      {:ok, :user_added_to_group} ->
+        conn
+        |> put_flash(:info, "User has been added to the group.")
+        |> redirect(to: admin_group_membership_request_path(conn, :index))
+      {:ok, :user_already_in_group} ->
+        conn
+        |> put_flash(:info, "User was already in group. Invitation removed.")
+        |> redirect(to: admin_group_membership_request_path(conn, :index))
+      {:error, :user_not_found} ->
+        conn
+        |> put_flash(:error, "User could not be found.")
+        |> redirect(to: admin_group_membership_request_path(conn, :index))
+      {:error, :group_membership_request_not_found} ->
+        conn
+        |> put_flash(:error, "Invitation could not be found.")
+        |> redirect(to: admin_group_membership_request_path(conn, :index))
+    end
+  end
+
+  @spec delete_invite_and_add_user_to_group(Types.user, Types.group_membership_request) ::
+    {:ok, :user_added_to_group | :user_already_in_group}
+  defp delete_invite_and_add_user_to_group(user, group_membership_request) do
+    group_id = group_membership_request.group_id
+    case retrieve_user_group(user.id, group_id) do
+      nil ->
+        changeset = UserGroup.changeset(%UserGroup{}, %{user_id: user.id, group_id: group_id})
+        multi = Ecto.Multi.new
+          |> Ecto.Multi.delete(:group_membership_request, group_membership_request)
+          |> Ecto.insert(:user_group, changeset)
+        Repo.transaction(multi)
+        {:ok, :user_added_to_group}
+      user_group ->
+        Repo.delete!(group_membership_request)
+        {:ok, :user_already_in_group}
+    end
+  end
+
+  @spec retrieve_user(non_neg_integer()) :: {:ok, Types.user} | {:error, :user_not_found}
+  defp retrieve_user(user_id) do
+    case Repo.get(User, user_id) do
+      user = %User{} -> {:ok, user}
+      _ = {:error, :user_not_found}
+    end
+  end
+
+  @spec retrieve_group_membership_request(non_neg_integer()) ::
+    {:ok, Types.group_membership_request} | {:error, :group_membership_request_not_found}
+  defp retrieve_group_membership_request(group_membership_request_id) do
+    case Repo.get(GroupMembershipRequest, group_membership_request_id) do
+      group_membership_request = %GroupMembershipRequest{} -> {:ok, group_membership_request}
+      _ = {:error, :group_membership_request_not_found}
+    end
+  end
+
+  defp retrieve_user_group(user_id, group_id) do
+    Repo.get_by(UserGroup, %{user_id: user_id, group_id: group_id})
+  end
+end

--- a/web/controllers/admin/invitation_accept_controller.ex
+++ b/web/controllers/admin/invitation_accept_controller.ex
@@ -11,21 +11,13 @@ defmodule Pairmotron.AdminInvitationAcceptController do
 
     case result do
       {:ok, :user_added_to_group} ->
-        conn
-        |> put_flash(:info, "User has been added to the group.")
-        |> redirect(to: admin_group_membership_request_path(conn, :index))
+        conn |> redirect_and_flash(:info, "User has been added to the group")
       {:ok, :user_already_in_group} ->
-        conn
-        |> put_flash(:info, "User was already in group. Invitation removed.")
-        |> redirect(to: admin_group_membership_request_path(conn, :index))
+        conn |> redirect_and_flash(:info, "User was already in group. Invitation removed.")
       {:error, :user_not_found} ->
-        conn
-        |> put_flash(:error, "User could not be found.")
-        |> redirect(to: admin_group_membership_request_path(conn, :index))
+        conn |> redirect_and_flash(:error, "User could not be found.")
       {:error, :group_membership_request_not_found} ->
-        conn
-        |> put_flash(:error, "Invitation could not be found.")
-        |> redirect(to: admin_group_membership_request_path(conn, :index))
+        conn |> redirect_and_flash(:info, "Invitation could not be found.")
     end
   end
 
@@ -47,7 +39,7 @@ defmodule Pairmotron.AdminInvitationAcceptController do
     end
   end
 
-  @spec retrieve_user(non_neg_integer()) :: {:ok, Types.user} | {:error, :user_not_found}
+  @spec retrieve_user(integer() | binary()) :: {:ok, Types.user} | {:error, :user_not_found}
   defp retrieve_user(user_id) do
     case Repo.get(User, user_id) do
       user = %User{} -> {:ok, user}
@@ -55,17 +47,24 @@ defmodule Pairmotron.AdminInvitationAcceptController do
     end
   end
 
-  @spec retrieve_group_membership_request(non_neg_integer()) ::
+  @spec retrieve_group_membership_request(integer() | binary()) ::
     {:ok, Types.group_membership_request} | {:error, :group_membership_request_not_found}
   defp retrieve_group_membership_request(group_membership_request_id) do
-    IO.inspect group_membership_request_id
     case Repo.get(GroupMembershipRequest, group_membership_request_id) do
       group_membership_request = %GroupMembershipRequest{} -> {:ok, group_membership_request}
       _ -> {:error, :group_membership_request_not_found}
     end
   end
 
+  @spec retrieve_user_group(integer(), integer()) :: Types.user_group | nil
   defp retrieve_user_group(user_id, group_id) do
     Repo.get_by(UserGroup, %{user_id: user_id, group_id: group_id})
+  end
+
+  @spec redirect_and_flash(Plug.Conn.t, atom(), String.t) :: Plug.Conn.t
+  defp redirect_and_flash(conn, message_type, message) do
+    conn
+    |> put_flash(message_type, message)
+    |> redirect(to: admin_group_membership_request_path(conn, :index))
   end
 end

--- a/web/controllers/admin/invitation_accept_controller.ex
+++ b/web/controllers/admin/invitation_accept_controller.ex
@@ -1,10 +1,10 @@
 defmodule Pairmotron.AdminInvitationAcceptController do
   use Pairmotron.Web, :controller
 
-  alias Pairmotron.{Group, GroupMembershipRequest, User, UserGroup}
+  alias Pairmotron.{GroupMembershipRequest, User, UserGroup}
 
   @spec update(Plug.Conn.t, map()) :: Plug.Conn.t
-  def update(conn, params = %{"user_id" => user_id, "group_membership_request_id" => group_membership_request_id}) do
+  def update(conn, %{"user_id" => user_id, "group_membership_request_id" => group_membership_request_id}) do
     result = with {:ok, user} <- retrieve_user(user_id),
                   {:ok, group_membership_request} <- retrieve_group_membership_request(group_membership_request_id),
                   do: delete_invite_and_add_user_to_group(user, group_membership_request)
@@ -33,7 +33,7 @@ defmodule Pairmotron.AdminInvitationAcceptController do
           |> Ecto.Multi.insert(:user_group, changeset)
         Repo.transaction(multi)
         {:ok, :user_added_to_group}
-      user_group ->
+      _user_group ->
         Repo.delete!(group_membership_request)
         {:ok, :user_already_in_group}
     end

--- a/web/router.ex
+++ b/web/router.ex
@@ -48,6 +48,7 @@ defmodule Pairmotron.Router do
     resources "/projects", AdminProjectController
     resources "/user_groups", AdminUserGroupController
     resources "/group_membership_requests", AdminGroupMembershipRequestController
+    put "/invitation_accept/:user_id/:group_membership_request_id", AdminInvitationAcceptController, :update
   end
 
   scope "/", Pairmotron do

--- a/web/templates/admin_group_membership_request/index.html.eex
+++ b/web/templates/admin_group_membership_request/index.html.eex
@@ -30,6 +30,7 @@
       </td>
       <td><%= group_membership_request.initiated_by_user %></td>
       <td class="text-right">
+        <%= link "Accept", to: admin_invitation_accept_path(@conn, :update, group_membership_request.user_id, group_membership_request.id), class: "btn btn-default btn-xs", method: :put %>
         <%= link "Show", to: admin_group_membership_request_path(@conn, :show, group_membership_request), class: "btn btn-default btn-xs" %>
         <%= link "Edit", to: admin_group_membership_request_path(@conn, :edit, group_membership_request), class: "btn btn-default btn-xs" %>
         <%= link "Delete", to: admin_group_membership_request_path(@conn, :delete, group_membership_request), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs" %>


### PR DESCRIPTION
Currently in the admin interface, if you want to have someone's invite accepted, you have to add the user to the group and then delete their group_membership_request record. This adds a button that handles both of those things directly from the group_membership_request list.

Closes #165 