### PR TITLE
Add email disabled to profile

### DIFF
--- a/lib/mailer/email.ex
+++ b/lib/mailer/email.ex
@@ -93,7 +93,7 @@ defmodule Pairmotron.Email do
   @spec unsubscribe_html() :: String.t
   defp unsubscribe_html() do
     """
-    If you would not like to receive further emails from pairmotron, follow 
+    If you would not like to receive further emails from Pairmotron, follow 
     <a href=#{user_profile_edit_path()}>this link</a> to disable emailing from 
     your profile.
     """
@@ -102,7 +102,7 @@ defmodule Pairmotron.Email do
   @spec unsubscribe_text() :: String.t
   defp unsubscribe_text() do
     """
-    If you would not like to receive further emails from pairmotron, follow this 
+    If you would not like to receive further emails from Pairmotron, follow this 
     link: #{user_profile_edit_path()} to disable emailing from your profile.
     """
   end

--- a/lib/mailer/email.ex
+++ b/lib/mailer/email.ex
@@ -65,20 +65,24 @@ defmodule Pairmotron.Email do
 
   @spec group_invitation_email_html_body(String.t) :: String.t
   defp group_invitation_email_html_body(group_name) do
-  """
-  You have been invited to join the #{group_name} group in Pairmotron!
-  <br><br>
-  <a href=#{invitation_index_path()}>Click here to view your invitations</a>
-  """
+    """
+    You have been invited to join the #{group_name} group in Pairmotron!
+    <br><br>
+    <a href=#{invitation_index_path()}>Click here to view your invitations</a>
+    <br><br>
+    #{unsubscribe_html()}
+    """
   end
 
   @spec group_invitation_email_text_body(String.t) :: String.t
   defp group_invitation_email_text_body(group_name) do
-  """
-  You have been invited to join the #{group_name} group in Pairmotron!
-  \n\n
-  Follow this link to view your invitations: #{invitation_index_path()}
-  """
+    """
+    You have been invited to join the #{group_name} group in Pairmotron!
+    \n\n
+    Follow this link to view your invitations: #{invitation_index_path()}
+    \n\n
+    #{unsubscribe_text()}
+    """
   end
 
   @spec invitation_index_path() :: String.t
@@ -86,4 +90,25 @@ defmodule Pairmotron.Email do
     users_group_membership_request_url(Pairmotron.Endpoint, :index)
   end
 
+  @spec unsubscribe_html() :: String.t
+  defp unsubscribe_html() do
+    """
+    If you would not like to receive further emails from pairmotron, follow 
+    <a href=#{user_profile_edit_path()}>this link</a> to disable emailing from 
+    your profile.
+    """
+  end
+
+  @spec unsubscribe_text() :: String.t
+  defp unsubscribe_text() do
+    """
+    If you would not like to receive further emails from pairmotron, follow this 
+    link: #{user_profile_edit_path()} to disable emailing from your profile.
+    """
+  end
+
+  @spec user_profile_edit_path() :: String.t
+  defp user_profile_edit_path() do
+    profile_url(Pairmotron.Endpoint, :edit)
+  end
 end

--- a/priv/repo/migrations/20161122030550_add_user_passwords.exs
+++ b/priv/repo/migrations/20161122030550_add_user_passwords.exs
@@ -2,13 +2,13 @@ defmodule Pairmotron.Repo.Migrations.AddUserPasswords do
   use Ecto.Migration
 
   def up do
-    default_hash = Comeonin.Bcrypt.hashpwsalt("password") 
+    default_hash = Comeonin.Bcrypt.hashpwsalt("password")
 
-    alter table(:users) do 
+    alter table(:users) do
       add :password_hash, :string
     end
 
-    flush
+    flush()
 
     Pairmotron.Repo.update_all("users", set: [password_hash: default_hash])
 

--- a/priv/repo/migrations/20170706150258_add_email_disabled_to_user.exs
+++ b/priv/repo/migrations/20170706150258_add_email_disabled_to_user.exs
@@ -1,0 +1,9 @@
+defmodule Pairmotron.Repo.Migrations.AddEmailDisabledToUser do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :email_disabled, :boolean, default: false, null: false
+    end
+  end
+end

--- a/priv/repo/migrations/20170706150258_add_email_disabled_to_user.exs
+++ b/priv/repo/migrations/20170706150258_add_email_disabled_to_user.exs
@@ -3,7 +3,7 @@ defmodule Pairmotron.Repo.Migrations.AddEmailDisabledToUser do
 
   def change do
     alter table(:users) do
-      add :email_disabled, :boolean, default: false, null: false
+      add :email_enabled, :boolean, default: true, null: false
     end
   end
 end

--- a/test/controllers/group_invitation_controller_test.exs
+++ b/test/controllers/group_invitation_controller_test.exs
@@ -142,7 +142,7 @@ defmodule Pairmotron.GroupInvitationControllerTest do
 
     test "does not send an email to the invited user if that user has email disabled", %{conn: conn, logged_in_user: user} do
       group = insert(:group, %{owner: user, users: [user]})
-      other_user = insert(:user, %{email_disabled: true})
+      other_user = insert(:user, %{email_enabled: false})
       attrs = %{user_id: other_user.id}
       post conn, group_invitation_path(conn, :create, group), group_membership_request: attrs
 

--- a/test/controllers/group_invitation_controller_test.exs
+++ b/test/controllers/group_invitation_controller_test.exs
@@ -140,6 +140,15 @@ defmodule Pairmotron.GroupInvitationControllerTest do
       assert_delivered_email Pairmotron.Email.group_invitation_email(other_user, group)
     end
 
+    test "does not send an email to the invited user if that user has email disabled", %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{owner: user, users: [user]})
+      other_user = insert(:user, %{email_disabled: true})
+      attrs = %{user_id: other_user.id}
+      post conn, group_invitation_path(conn, :create, group), group_membership_request: attrs
+
+      refute_delivered_email Pairmotron.Email.group_invitation_email(other_user, group)
+    end
+
     test "can create a group_membership_request if current_user is admin of group", %{conn: conn, logged_in_user: user} do
       group = insert(:group)
       insert(:user_group, %{user: user, group: group, is_admin: true})

--- a/test/controllers/password_reset_controller_test.exs
+++ b/test/controllers/password_reset_controller_test.exs
@@ -27,7 +27,7 @@ defmodule Pairmotron.PasswordResetControllerTest do
     end
 
     test "sends a password reset email if user exists even if that user has email disabled", %{conn: conn} do
-      user = insert(:user, %{email_disabled: true})
+      user = insert(:user, %{email_enabled: false})
       post conn, password_reset_path(conn, :create), password_reset_token: %{email: user.email}
       token = Repo.get_by(PasswordResetToken, user_id: user.id) |> Repo.preload(:user)
       assert_delivered_email Pairmotron.Email.password_reset_email(token)

--- a/test/controllers/password_reset_controller_test.exs
+++ b/test/controllers/password_reset_controller_test.exs
@@ -26,6 +26,13 @@ defmodule Pairmotron.PasswordResetControllerTest do
       assert_delivered_email Pairmotron.Email.password_reset_email(token)
     end
 
+    test "sends a password reset email if user exists even if that user has email disabled", %{conn: conn} do
+      user = insert(:user, %{email_disabled: true})
+      post conn, password_reset_path(conn, :create), password_reset_token: %{email: user.email}
+      token = Repo.get_by(PasswordResetToken, user_id: user.id) |> Repo.preload(:user)
+      assert_delivered_email Pairmotron.Email.password_reset_email(token)
+    end
+
     test "does not create a PasswordResetToken if user does not exist with given email", %{conn: conn} do
       conn = post conn, password_reset_path(conn, :create), password_reset_token: %{email: "null@email.com"}
       assert [] = Repo.all(PasswordResetToken)

--- a/web/controllers/group_invitation_controller.ex
+++ b/web/controllers/group_invitation_controller.ex
@@ -90,7 +90,7 @@ defmodule Pairmotron.GroupInvitationController do
 
   @spec send_group_invitation_email(Types.user, Types.group) :: any
   defp send_group_invitation_email(user, group) do
-    unless user.email_disabled do
+    if user.email_enabled do
       user
       |> Pairmotron.Email.group_invitation_email(group)
       |> Pairmotron.Mailer.deliver_later

--- a/web/controllers/group_invitation_controller.ex
+++ b/web/controllers/group_invitation_controller.ex
@@ -90,9 +90,11 @@ defmodule Pairmotron.GroupInvitationController do
 
   @spec send_group_invitation_email(Types.user, Types.group) :: any
   defp send_group_invitation_email(user, group) do
-    user
-    |> Pairmotron.Email.group_invitation_email(group)
-    |> Pairmotron.Mailer.deliver_later
+    unless user.email_disabled do
+      user
+      |> Pairmotron.Email.group_invitation_email(group)
+      |> Pairmotron.Mailer.deliver_later
+    end
   end
 
   @spec invitable_users_for_select(Types.group) :: [{binary(), integer()}]

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -33,7 +33,7 @@ defmodule Pairmotron.User do
 
   @minimum_password_length 8
 
-  @all_params ~w(name email password password_confirmation active is_admin)
+  @all_params ~w(name email password password_confirmation active is_admin email_disabled)
   @required_params [:name, :email]
 
   @doc """
@@ -69,7 +69,7 @@ defmodule Pairmotron.User do
     |> common_changeset
   end
 
-  @all_profile_params ~w(name email active password password_confirmation)
+  @all_profile_params ~w(name email active password password_confirmation email_disabled)
   @required_profile_params [:name, :email]
 
   @doc """

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -18,7 +18,7 @@ defmodule Pairmotron.User do
     field :email, :string
     field :active, :boolean
     field :is_admin, :boolean
-    field :email_disabled, :boolean
+    field :email_enabled, :boolean
 
     field :password, :string, virtual: true
     field :password_confirmation, :string, virtual: true
@@ -33,7 +33,7 @@ defmodule Pairmotron.User do
 
   @minimum_password_length 8
 
-  @all_params ~w(name email password password_confirmation active is_admin email_disabled)
+  @all_params ~w(name email password password_confirmation active is_admin email_enabled)
   @required_params [:name, :email]
 
   @doc """
@@ -69,7 +69,7 @@ defmodule Pairmotron.User do
     |> common_changeset
   end
 
-  @all_profile_params ~w(name email active password password_confirmation email_disabled)
+  @all_profile_params ~w(name email active password password_confirmation email_enabled)
   @required_profile_params [:name, :email]
 
   @doc """

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -18,6 +18,7 @@ defmodule Pairmotron.User do
     field :email, :string
     field :active, :boolean
     field :is_admin, :boolean
+    field :email_disabled, :boolean
 
     field :password, :string, virtual: true
     field :password_confirmation, :string, virtual: true

--- a/web/templates/admin_user/form.html.eex
+++ b/web/templates/admin_user/form.html.eex
@@ -24,6 +24,12 @@
   </div>
 
   <div class="form-group">
+    <%= label f, :email_disabled, class: "control-label" %>
+    <%= checkbox f, :email_disabled, class: "form-control" %>
+    <%= error_tag f, :email_disabled %>
+  </div>
+
+  <div class="form-group">
     <%= label f, :is_admin, class: "control-label" %>
     <%= checkbox f, :is_admin, class: "form-control" %>
     <%= error_tag f, :is_admin %>

--- a/web/templates/admin_user/form.html.eex
+++ b/web/templates/admin_user/form.html.eex
@@ -24,9 +24,9 @@
   </div>
 
   <div class="form-group">
-    <%= label f, :email_disabled, class: "control-label" %>
-    <%= checkbox f, :email_disabled, class: "form-control" %>
-    <%= error_tag f, :email_disabled %>
+    <%= label f, :email_enabled, class: "control-label" %>
+    <%= checkbox f, :email_enabled, class: "form-control" %>
+    <%= error_tag f, :email_enabled %>
   </div>
 
   <div class="form-group">

--- a/web/templates/admin_user/index.html.eex
+++ b/web/templates/admin_user/index.html.eex
@@ -8,7 +8,7 @@
       <th>Email</th>
       <th>Active</th>
       <th>Admin</th>
-      <th>Email Disabled</th>
+      <th>Email Enabled</th>
       <th></th>
     </tr>
   </thead>
@@ -20,7 +20,7 @@
       <td><%= user.email %></td>
       <td><%= user.active %></td>
       <td><%= user.is_admin %></td>
-      <td><%= user.email_disabled %></td>
+      <td><%= user.email_enabled %></td>
       <td class="text-right">
         <%= link "Show", to: admin_user_path(@conn, :show, user), class: "btn btn-default btn-xs" %>
         <%= link "Edit", to: admin_user_path(@conn, :edit, user), class: "btn btn-default btn-xs" %>

--- a/web/templates/admin_user/index.html.eex
+++ b/web/templates/admin_user/index.html.eex
@@ -8,6 +8,7 @@
       <th>Email</th>
       <th>Active</th>
       <th>Admin</th>
+      <th>Email Disabled</th>
       <th></th>
     </tr>
   </thead>
@@ -19,6 +20,7 @@
       <td><%= user.email %></td>
       <td><%= user.active %></td>
       <td><%= user.is_admin %></td>
+      <td><%= user.email_disabled %></td>
       <td class="text-right">
         <%= link "Show", to: admin_user_path(@conn, :show, user), class: "btn btn-default btn-xs" %>
         <%= link "Edit", to: admin_user_path(@conn, :edit, user), class: "btn btn-default btn-xs" %>

--- a/web/templates/admin_user/show.html.eex
+++ b/web/templates/admin_user/show.html.eex
@@ -27,6 +27,11 @@
     <%= @user.is_admin %>
   </li>
 
+  <li>
+    <strong>Email disabled</strong>
+    <%= @user.email_disabled %>
+  </li>
+
 </ul>
 
 <%= link "Edit", to: admin_user_path(@conn, :edit, @user) %>

--- a/web/templates/admin_user/show.html.eex
+++ b/web/templates/admin_user/show.html.eex
@@ -28,8 +28,8 @@
   </li>
 
   <li>
-    <strong>Email disabled</strong>
-    <%= @user.email_disabled %>
+    <strong>Email enabled</strong>
+    <%= @user.email_enabled %>
   </li>
 
 </ul>

--- a/web/templates/profile/form.html.eex
+++ b/web/templates/profile/form.html.eex
@@ -36,6 +36,12 @@
   </div>
 
   <div class="form-group">
+    <%= label f, :email_disabled, class: "control-label" %>
+    <%= checkbox f, :email_disabled %>
+    <%= error_tag f, :email_disabled %>
+  </div>
+
+  <div class="form-group">
     <%= submit "Submit", class: "btn btn-primary" %>
   </div>
 <% end %>

--- a/web/templates/profile/form.html.eex
+++ b/web/templates/profile/form.html.eex
@@ -36,9 +36,9 @@
   </div>
 
   <div class="form-group">
-    <%= label f, :email_disabled, class: "control-label" %>
-    <%= checkbox f, :email_disabled %>
-    <%= error_tag f, :email_disabled %>
+    <%= label f, :email_enabled, class: "control-label" %>
+    <%= checkbox f, :email_enabled %>
+    <%= error_tag f, :email_enabled %>
   </div>
 
   <div class="form-group">


### PR DESCRIPTION
Adds an "Email disabled" toggle to the users profile. This toggle allows the user to specify whether or not they'd like to receive email from pairmotron (currently only the group invitation email is applicable here). The only email that is exempted from this is the password_reset email.

Closes #172 

