### PR TITLE
Fix error when updating retro with no project

### DIFF
--- a/test/controllers/pair_retro_controller_test.exs
+++ b/test/controllers/pair_retro_controller_test.exs
@@ -311,6 +311,18 @@ defmodule Pairmotron.PairRetroControllerTest do
       assert Repo.get_by(PairRetro, attrs)
     end
 
+    test 'updates retro if project_id param is "" (no project selected)', %{conn: conn, logged_in_user: user} do
+      group = insert(:group, %{owner: user, users: [user]})
+      pair = insert(:pair, %{group: group, users: [user]})
+      pair_retro = insert(:retro, %{user: user, pair: pair})
+
+      attrs = Map.merge(@valid_attrs, %{project_id: "", subject: "different subject"})
+
+      conn = put conn, pair_retro_path(conn, :update, pair_retro), pair_retro: attrs
+      assert redirected_to(conn) == pair_retro_path(conn, :show, pair_retro)
+      assert Repo.get_by(PairRetro, %{subject: "different subject"})
+    end
+
     test "fails with a pair_date before the pair's week", %{conn: conn, logged_in_user: user} do
       group = insert(:group, %{owner: user, users: [user]})
       pair = insert(:pair, %{group: group, users: [user], year: 2016, week: 1})

--- a/web/controllers/pair_retro_controller.ex
+++ b/web/controllers/pair_retro_controller.ex
@@ -121,6 +121,7 @@ defmodule Pairmotron.PairRetroController do
   defp project_from_params_or_pair_retro(params, pair_retro) do
     case Map.get(params, "project_id") || (pair_retro.project && pair_retro.project.id) do
       nil -> nil
+      "" -> nil
       id -> Repo.get(Project, id)
     end
   end


### PR DESCRIPTION
Fixes an error when updating a retro that has no associated project.

Looks like there was no test coverage around this case for update, while there was for the create. Uncovered this trying to change the date of a retro that didn't have an associated project in production.