### PR TITLE
Add accomplice for grouping

### DIFF
--- a/lib/pairmotron/pairer.ex
+++ b/lib/pairmotron/pairer.ex
@@ -25,23 +25,20 @@ defmodule Pairmotron.Pairer do
   end
 
   @spec generate_pairs([Types.user]) :: %PairerResult{pairs: [Types.pair]}
+  def generate_pairs([]), do: %PairerResult{pairs: []}
+  def generate_pairs([user]), do: %PairerResult{pairs: [[user]]}
   def generate_pairs(users) do
-    users
-      |> chunk
-      |> unlonelify
+    case users |> Accomplice.group(%{minimum: 2, ideal: 2, maximum: 3}) do
+      :impossible -> :impossible
+      pairs ->
+        reversed_pairs = pairs |> Enum.reverse
+        %PairerResult{pairs: reversed_pairs}
+    end
   end
 
   defp chunk(users) do
     users
       |> Enum.chunk(2, 2, [])
-  end
-
-  defp unlonelify(pairs) do
-    results = pairs
-      |> Enum.reverse
-      |> friendify
-      |> Enum.reverse
-    %PairerResult{pairs: results}
   end
 
   defp unlonelify([], _), do: %PairerResult{}
@@ -61,9 +58,8 @@ defmodule Pairmotron.Pairer do
   defp unlonelify([[single]], [%Pair{users: [_1, _2]} | pairs]), do: unlonelify([[single]], pairs)
   defp unlonelify([[single]], [%Pair{users: [_1, _2, _3]} | pairs]), do: unlonelify([[single]], pairs)
 
-
   defp friendify(pairs = [[_first, _second] | _rest]), do: pairs
-  defp friendify([[single] | [pair | rest]]) do
+  defp friendify([[single], pair | rest]) do
     [[single | pair] | rest]
   end
   defp friendify(pairs), do: pairs

--- a/lib/pairmotron/pairer.ex
+++ b/lib/pairmotron/pairer.ex
@@ -21,7 +21,7 @@ defmodule Pairmotron.Pairer do
     # Recurse the list until we find a pair we can add the single user to (1 or
     # 2 users in pair). If we don't find a suitable pair, create a new single
     # user pair.
-    unlonelify([[user]], pairs |> sort_pairs_by_length)
+    try_add_to_non_full_pair(user, pairs)
   end
   def generate_pairs(users, _pairs) do
     # More than one user to add. Let Accomplice group the new users into pairs
@@ -37,17 +37,21 @@ defmodule Pairmotron.Pairer do
     %PairerResult{pairs: pairs}
   end
 
+  defp try_add_to_non_full_pair(user, pairs) do 
+    try_add_to_pair(user, pairs |> sort_pairs_by_length)
+  end
+
   defp sort_pairs_by_length(pairs) do
     pairs |> Enum.sort_by(fn(pair) -> length(pair.users) end)
   end
 
-  defp unlonelify([[single]], []), do: %PairerResult{pairs: [[single]]}
-  defp unlonelify([[single]], [pair = %Pair{users: [_1]} | _]) do
-    %PairerResult{user_pair: UserPair.changeset(%UserPair{}, %{pair_id: pair.id, user_id: single.id})}
+  defp try_add_to_pair(user, []), do: %PairerResult{pairs: [[user]]}
+  defp try_add_to_pair(user, [pair = %Pair{users: [_1]} | _]) do
+    %PairerResult{user_pair: UserPair.changeset(%UserPair{}, %{pair_id: pair.id, user_id: user.id})}
   end
-  defp unlonelify([[single]], [pair = %Pair{users: [_1, _2]} | _]) do
-    %PairerResult{user_pair: UserPair.changeset(%UserPair{}, %{pair_id: pair.id, user_id: single.id})}
+  defp try_add_to_pair(user, [pair = %Pair{users: [_1, _2]} | _]) do
+    %PairerResult{user_pair: UserPair.changeset(%UserPair{}, %{pair_id: pair.id, user_id: user.id})}
   end
-  defp unlonelify([[single]], [%Pair{users: [_1, _2, _3]} | pairs]), do: unlonelify([[single]], pairs)
+  defp try_add_to_pair(user, _), do: %PairerResult{pairs: [[user]]}
 
 end

--- a/lib/pairmotron/pairer.ex
+++ b/lib/pairmotron/pairer.ex
@@ -14,57 +14,40 @@ defmodule Pairmotron.Pairer do
   alias Pairmotron.{Pair, Types, UserPair}
 
   @spec generate_pairs([Types.user], [Types.pair]) :: %PairerResult{}
-  def generate_pairs(users, []), do: generate_pairs(users)
-  def generate_pairs(users, pairs) do
-    sorted_pairs = pairs |> sort_pairs_by_length
-    users
-      |> chunk
-      |> Enum.reverse
-      |> friendify
-      |> Enum.reverse
-      |> unlonelify(sorted_pairs)
+  # No existing pairs. Generate new ones.
+  def generate_pairs(users, []), do: generate_new_pairs(users)
+  def generate_pairs([user], pairs) do
+    # Just one user to add. Sort the list so that shorter pairs are first.
+    # Recurse the list until we find a pair we can add the single user to (1 or
+    # 2 users in pair). If we don't find a suitable pair, create a new single
+    # user pair.
+    unlonelify([[user]], pairs |> sort_pairs_by_length)
+  end
+  def generate_pairs(users, _pairs) do
+    # More than one user to add. Let Accomplice group the new users into pairs
+    # just like it would if there were no pairs. Old pairs are not relevant.
+    generate_new_pairs(users)
   end
 
-  @spec generate_pairs([Types.user]) :: %PairerResult{pairs: [Types.pair]}
-  def generate_pairs([]), do: %PairerResult{pairs: []}
-  def generate_pairs([user]), do: %PairerResult{pairs: [[user]]}
-  def generate_pairs(users) do
-    case users |> Accomplice.group(%{minimum: 2, ideal: 2, maximum: 3}) do
-      :impossible -> :impossible
-      pairs -> %PairerResult{pairs: pairs}
-    end
-  end
-
-  defp chunk(users) do
-    users
-      |> Enum.chunk(2, 2, [])
+  @spec generate_new_pairs([Types.user]) :: %PairerResult{pairs: [Types.pair]}
+  defp generate_new_pairs([]), do: %PairerResult{pairs: []}
+  defp generate_new_pairs([user]), do: %PairerResult{pairs: [[user]]}
+  defp generate_new_pairs(users) do
+    pairs = users |> Accomplice.group(%{minimum: 2, ideal: 2, maximum: 3})
+    %PairerResult{pairs: pairs}
   end
 
   defp sort_pairs_by_length(pairs) do
-    pairs |> Enum.sort_by(fn(pair) -> -length(pair.users) end)
+    pairs |> Enum.sort_by(fn(pair) -> length(pair.users) end)
   end
 
-  defp unlonelify([], _), do: %PairerResult{}
-  defp unlonelify(users = [[_1, _2]], _), do: %PairerResult{pairs: users}
-  defp unlonelify(users = [[_1, _2, _3]], _), do: %PairerResult{pairs: users}
-  defp unlonelify(users = [[_1, _2] | _], _), do: %PairerResult{pairs: users}
-  defp unlonelify(users = [[_]], [%Pair{users: [_1, _2, _3]}]), do: %PairerResult{pairs: users}
-  defp unlonelify([[single]], [pair = %Pair{users: [_1, _2]}]) do
-    %PairerResult{user_pair: UserPair.changeset(%UserPair{}, %{pair_id: pair.id, user_id: single.id})}
-  end
-  defp unlonelify([[single]], [pair = %Pair{users: [_1]}]) do
-    %PairerResult{user_pair: UserPair.changeset(%UserPair{}, %{pair_id: pair.id, user_id: single.id})}
-  end
+  defp unlonelify([[single]], []), do: %PairerResult{pairs: [[single]]}
   defp unlonelify([[single]], [pair = %Pair{users: [_1]} | _]) do
     %PairerResult{user_pair: UserPair.changeset(%UserPair{}, %{pair_id: pair.id, user_id: single.id})}
   end
-  defp unlonelify([[single]], [%Pair{users: [_1, _2]} | pairs]), do: unlonelify([[single]], pairs)
-  defp unlonelify([[single]], [%Pair{users: [_1, _2, _3]} | pairs]), do: unlonelify([[single]], pairs)
-
-  defp friendify(pairs = [[_first, _second] | _rest]), do: pairs
-  defp friendify([[single], pair | rest]) do
-    [[single | pair] | rest]
+  defp unlonelify([[single]], [pair = %Pair{users: [_1, _2]} | _]) do
+    %PairerResult{user_pair: UserPair.changeset(%UserPair{}, %{pair_id: pair.id, user_id: single.id})}
   end
-  defp friendify(pairs), do: pairs
+  defp unlonelify([[single]], [%Pair{users: [_1, _2, _3]} | pairs]), do: unlonelify([[single]], pairs)
 
 end

--- a/lib/pairmotron/pairer.ex
+++ b/lib/pairmotron/pairer.ex
@@ -16,12 +16,13 @@ defmodule Pairmotron.Pairer do
   @spec generate_pairs([Types.user], [Types.pair]) :: %PairerResult{}
   def generate_pairs(users, []), do: generate_pairs(users)
   def generate_pairs(users, pairs) do
+    sorted_pairs = pairs |> sort_pairs_by_length
     users
       |> chunk
       |> Enum.reverse
       |> friendify
       |> Enum.reverse
-      |> unlonelify(pairs |> Enum.sort_by(fn(p) -> length(p.users) end) |> Enum.reverse)
+      |> unlonelify(sorted_pairs)
   end
 
   @spec generate_pairs([Types.user]) :: %PairerResult{pairs: [Types.pair]}
@@ -30,15 +31,17 @@ defmodule Pairmotron.Pairer do
   def generate_pairs(users) do
     case users |> Accomplice.group(%{minimum: 2, ideal: 2, maximum: 3}) do
       :impossible -> :impossible
-      pairs ->
-        reversed_pairs = pairs |> Enum.reverse
-        %PairerResult{pairs: reversed_pairs}
+      pairs -> %PairerResult{pairs: pairs}
     end
   end
 
   defp chunk(users) do
     users
       |> Enum.chunk(2, 2, [])
+  end
+
+  defp sort_pairs_by_length(pairs) do
+    pairs |> Enum.sort_by(fn(pair) -> -length(pair.users) end)
   end
 
   defp unlonelify([], _), do: %PairerResult{}

--- a/mix.exs
+++ b/mix.exs
@@ -49,6 +49,7 @@ defmodule Pairmotron.Mixfile do
      {:dialyxir, "~> 0.5", only: [:dev], runtime: false},
      {:html_sanitize_ex, "~> 1.0.0"},
      {:accomplice, "~> 0.1.0"},
+     {:order_invariant_compare, "~> 1.0.0", only: :test},
      {:bamboo, "~> 0.8"}]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -48,6 +48,7 @@ defmodule Pairmotron.Mixfile do
      {:credo, "~> 0.5", only: [:dev, :test]},
      {:dialyxir, "~> 0.5", only: [:dev], runtime: false},
      {:html_sanitize_ex, "~> 1.0.0"},
+     {:accomplice, "~> 0.1.0"},
      {:bamboo, "~> 0.8"}]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -35,6 +35,7 @@
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "mix_test_watch": {:hex, :mix_test_watch, "0.2.6", "9fcc2b1b89d1594c4a8300959c19d50da2f0ff13642c8f681692a6e507f92cab", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, optional: false]}]},
   "mochiweb": {:hex, :mochiweb, "2.12.2", "80804ad342afa3d7f3524040d4eed66ce74b17a555de454ac85b07c479928e46", [:make, :rebar], []},
+  "order_invariant_compare": {:hex, :order_invariant_compare, "1.0.0", "1b36603ccc01f098662cde92c7972387a93adfb16f1bcfbd1305e234b04aff84", [], [], "hexpm"},
   "phoenix": {:hex, :phoenix, "1.2.1", "6dc592249ab73c67575769765b66ad164ad25d83defa3492dc6ae269bd2a68ab", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:phoenix_pubsub, "~> 1.0", [hex: :phoenix_pubsub, optional: false]}, {:plug, "~> 1.1", [hex: :plug, optional: false]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: false]}]},
   "phoenix_ecto": {:hex, :phoenix_ecto, "3.2.3", "450c749876ff1de4a78fdb305a142a76817c77a1cd79aeca29e5fc9a6c630b26", [:mix], [{:ecto, "~> 2.1", [hex: :ecto, optional: false]}, {:phoenix_html, "~> 2.9", [hex: :phoenix_html, optional: true]}, {:plug, "~> 1.0", [hex: :plug, optional: false]}]},
   "phoenix_html": {:hex, :phoenix_html, "2.9.3", "1b5a2122cbf743aa242f54dced8a4f1cc778b8bd304f4b4c0043a6250c58e258", [:mix], [{:plug, "~> 1.0", [hex: :plug, optional: false]}]},

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
-%{"bamboo": {:hex, :bamboo, "0.8.0", "573889a3efcb906bb9d25a1c4caa4ca22f479235e1b8cc3260d8b88dabeb4b14", [:mix], [{:hackney, "~> 1.6", [hex: :hackney, optional: false]}, {:plug, "~> 1.0", [hex: :plug, optional: false]}, {:poison, ">= 1.5.0", [hex: :poison, optional: false]}]},
+%{"accomplice": {:hex, :accomplice, "0.1.0", "1e56479345a6ad934dbaa3d08c8ad19dcfa0c47464d5a5122abd7eac7d0ab5ac", [], [], "hexpm"},
+  "bamboo": {:hex, :bamboo, "0.8.0", "573889a3efcb906bb9d25a1c4caa4ca22f479235e1b8cc3260d8b88dabeb4b14", [:mix], [{:hackney, "~> 1.6", [hex: :hackney, optional: false]}, {:plug, "~> 1.0", [hex: :plug, optional: false]}, {:poison, ">= 1.5.0", [hex: :poison, optional: false]}]},
   "base64url": {:hex, :base64url, "0.0.1", "36a90125f5948e3afd7be97662a1504b934dd5dac78451ca6e9abf85a10286be", [:rebar], []},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
   "canada": {:hex, :canada, "1.0.1", "da96d0ff101a0c2a6cc7b07d92b8884ff6508f058781d3679999416feacf41c5", [:mix], []},

--- a/test/lib/pairer_test.exs
+++ b/test/lib/pairer_test.exs
@@ -27,40 +27,6 @@ defmodule Pairmotron.PairerTest do
     true
   end
 
-  describe ".generate_pairs/1" do
-    test "empty list of users returns empty list" do
-      assert %PairerResult{pairs: []} = Pairer.generate_pairs([])
-    end
-
-    test "list of one user returns a pair of that user" do
-      assert %PairerResult{pairs: [[@user_1]]} == Pairer.generate_pairs([@user_1])
-    end
-
-    test "list of two users returns a pair of those users" do
-      assert %PairerResult{pairs: [first_pair]} = Pairer.generate_pairs([@user_1, @user_2])
-      assert Enum.sort(first_pair) == [@user_1, @user_2]
-    end
-
-    test "list of four users returns two pairs of those users" do
-      assert %PairerResult{pairs: pairs} = Pairer.generate_pairs([@user_1, @user_2, @user_3, @user_4])
-      assert length(pairs) == 2
-      assert List.flatten(pairs) <~> [@user_1, @user_2, @user_3, @user_4]
-      assert pairs |> grouping_is([2, 2])
-    end
-
-    test "list of three users returns one pair of those three users" do
-      assert %PairerResult{pairs: [first_pair]} = Pairer.generate_pairs([@user_1, @user_2, @user_3])
-      assert Enum.sort(first_pair) == [@user_1, @user_2, @user_3]
-    end
-
-    test "list of five users returns two pairs with the three person pair at the end" do
-      assert %PairerResult{pairs: pairs} = Pairer.generate_pairs([@user_1, @user_2, @user_3, @user_4, @user_5])
-      assert length(pairs) == 2
-      assert List.flatten(pairs) <~> [@user_1, @user_2, @user_3, @user_4, @user_5]
-      assert pairs |> grouping_is([2, 3])
-    end
-  end
-
   describe ".generate_pairs/2" do
     test "empty list of users and empty user pairs returns empty list" do
       assert %PairerResult{user_pair: nil, pairs: []} = Pairer.generate_pairs([], [])
@@ -97,7 +63,8 @@ defmodule Pairmotron.PairerTest do
     end
 
     test "two new users with existing pair get matched as a new pair" do
-      assert %PairerResult{pairs: [[@user_3, @user_4]]} = Pairer.generate_pairs([@user_3, @user_4], [@pair1])
+      assert %PairerResult{pairs: [new_pair]} = Pairer.generate_pairs([@user_3, @user_4], [@pair1])
+      assert new_pair <~> [@user_3, @user_4]
     end
 
     test "three new users with existing pair get matched as a new three pair" do
@@ -106,7 +73,10 @@ defmodule Pairmotron.PairerTest do
     end
 
     test "four new users with an existing pair get matched as two new pairs" do
-      assert %PairerResult{pairs: [[@user_3, @user_4], [@user_5, @user_6]]} = Pairer.generate_pairs([@user_3, @user_4, @user_5, @user_6], [@pair1])
+      assert %PairerResult{pairs: new_pairs} = Pairer.generate_pairs([@user_3, @user_4, @user_5, @user_6], [@pair1])
+      assert length(new_pairs) == 2
+      assert List.flatten(new_pairs) <~> [@user_3, @user_4, @user_5, @user_6]
+      assert new_pairs |> grouping_is([2, 2])
     end
   end
 end

--- a/test/lib/pairer_test.exs
+++ b/test/lib/pairer_test.exs
@@ -3,6 +3,8 @@ defmodule Pairmotron.PairerTest do
 
   alias Pairmotron.{Pairer, User, UserPair, Pair}
 
+  import OrderInvariantCompare
+
   @user_1 %User{id: 1}
   @user_2 %User{id: 2}
   @user_3 %User{id: 3}
@@ -16,6 +18,14 @@ defmodule Pairmotron.PairerTest do
 
   @user_pair_changeset UserPair.changeset(%UserPair{}, %{pair_id: 1, user_id: 5})
   @user_pair_changeset2 UserPair.changeset(%UserPair{}, %{pair_id: 3, user_id: 5})
+
+  def grouping_is(grouping, expected_grouping) when is_list(grouping) do
+    group_counts = Enum.map(grouping, fn element -> length(element) end)
+    unless group_counts <~> expected_grouping do
+      flunk("expected grouping of #{inspect expected_grouping} \ngot grouping of      #{inspect group_counts}")
+    end
+    true
+  end
 
   describe ".generate_pairs/1" do
     test "empty list of users returns empty list" do
@@ -32,9 +42,10 @@ defmodule Pairmotron.PairerTest do
     end
 
     test "list of four users returns two pairs of those users" do
-      assert %PairerResult{pairs: [first_pair, second_pair]} = Pairer.generate_pairs([@user_1, @user_2, @user_3, @user_4])
-      assert Enum.sort(first_pair) == [@user_1, @user_2]
-      assert Enum.sort(second_pair) == [@user_3, @user_4]
+      assert %PairerResult{pairs: pairs} = Pairer.generate_pairs([@user_1, @user_2, @user_3, @user_4])
+      assert length(pairs) == 2
+      assert List.flatten(pairs) <~> [@user_1, @user_2, @user_3, @user_4]
+      assert pairs |> grouping_is([2, 2])
     end
 
     test "list of three users returns one pair of those three users" do
@@ -43,9 +54,10 @@ defmodule Pairmotron.PairerTest do
     end
 
     test "list of five users returns two pairs with the three person pair at the end" do
-      assert %PairerResult{pairs: [first_pair, second_pair]} = Pairer.generate_pairs([@user_1, @user_2, @user_3, @user_4, @user_5])
-      assert Enum.sort(first_pair) == [@user_1, @user_2]
-      assert Enum.sort(second_pair) == [@user_3, @user_4, @user_5]
+      assert %PairerResult{pairs: pairs} = Pairer.generate_pairs([@user_1, @user_2, @user_3, @user_4, @user_5])
+      assert length(pairs) == 2
+      assert List.flatten(pairs) <~> [@user_1, @user_2, @user_3, @user_4, @user_5]
+      assert pairs |> grouping_is([2, 3])
     end
   end
 


### PR DESCRIPTION
Adds the Accomplice library which can pair up any number of users to replace the current logic in the `Pairer` module. This offloads a bunch of that logic to a library that is more generic, and generally make a lot of the code in the `Pairer` module a lot easier to understand.

This also paves the way for future groups to be able to configure what sizes of groups they'd like to generate, as the Accomplice library allows the specification of these parameters.

This also paves the way for groups to be able to prevent users from previous weeks from pairing again, as well as giving users the ability to specify that they would like to be paired with someone specifically the following week.

This also adds the OrderInvariantCompare library which can be useful for testing lists lists of values when you don't really care about the order of the elements of the returned lists, you just care about how many elements are in each list.